### PR TITLE
Fixes RuntimeWarning for improper buffering on local connection in Python 3.8+

### DIFF
--- a/mitogen/core.py
+++ b/mitogen/core.py
@@ -3860,7 +3860,7 @@ class ExternalContext(object):
         else:
             core_src_fd = self.config.get('core_src_fd', 101)
             if core_src_fd:
-                fp = os.fdopen(core_src_fd, 'rb', 1)
+                fp = os.fdopen(core_src_fd, 'rb', 0)
                 try:
                     core_src = fp.read()
                     # Strip "ExternalContext.main()" call from last line.


### PR DESCRIPTION
```bash
[mux  24512] 18:54:08.981562 D mitogen.io: EpollPoller.poll(29.704136800002743)
/home/metricmike/.asdf/installs/python/3.8.5/lib/python3.8/os.py:1023: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
  return io.open(fd, *args, **kwargs)
```
Change in Python 3.8 is described at https://bugs.python.org/issue32236
tl;dr - python used to silently ignore `open(fd, 'rb', 1)` on binary mode, now they don't because it could potentially cause issues

During the Python3 port, mitogen switched a file descriptor at (https://github.com/dw/mitogen/commit/410016ff479b717b2066cb3e1c673658d1ab43fe#diff-3540c3617f4566023f000914cebe2d71L1764-R1831) from text to binary mode on this commit, but left line buffering on. As far as I can tell, this is the only file descriptor where both the mode and buffering option didn't remain consistent on that commit.
![image](https://user-images.githubusercontent.com/311365/91237066-9d6a5400-e707-11ea-99d5-b05e4cc06897.png)

When building from this commit, the warning goes away and my not super trivial playbook runs successfully so this should solve issues #691 and #720, but I ran into several issues while building/testing and would appreciate some help verifying:
- Python 3.8 breaks at least the CFFI version used in `tests/requirements.txt`. Bumping that to 1.14.2 allows `.ci/localhost_ansible_install.py` to finish.
- Ubuntu 18.04 and up remove /usr/bin/python, so I needed to alias that to python3 in order to get `.ci/localhost_ansible_tests.py` to partially pass
- brew is expected but not installed for `.ci/localhost_ansible_tests.py`
- `.ci/*` expect a clean machine and I was building/testing locally