### PR TITLE
tests: Correct DISTRO vs DISTROS usage in CI configurations

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -17,7 +17,6 @@ jobs:
       Mito27_27:
         python.version: '2.7'
         MODE: mitogen
-        VER: 2.10.0
       # TODO: test python3, python3 tests are broken
       Ans210_27:
         python.version: '2.7'
@@ -46,7 +45,6 @@ jobs:
         python.version: '2.7'
         MODE: mitogen
         DISTRO: debian
-        VER: 2.10.0
 
       #MitoPy27CentOS6_26:
         #python.version: '2.7'
@@ -57,13 +55,11 @@ jobs:
         python.version: '3.6'
         MODE: mitogen
         DISTRO: centos6
-        VER: 2.10.0
 
       Mito37Debian_27:
         python.version: '3.7'
         MODE: mitogen
         DISTRO: debian
-        VER: 2.10.0
 
       #Py26CentOS7:
         #python.version: '2.7'

--- a/.ci/ci_lib.py
+++ b/.ci/ci_lib.py
@@ -149,9 +149,12 @@ class Fold(object):
 
 os.environ.setdefault('ANSIBLE_STRATEGY',
     os.environ.get('STRATEGY', 'mitogen_linear'))
+# Ignoreed when MODE=mitogen
 ANSIBLE_VERSION = os.environ.get('VER', '2.6.2')
 GIT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+# Used only when MODE=mitogen
 DISTRO = os.environ.get('DISTRO', 'debian')
+# Used only when MODE=ansible
 DISTROS = os.environ.get('DISTROS', 'debian centos6 centos7').split()
 TARGET_COUNT = int(os.environ.get('TARGET_COUNT', '2'))
 BASE_PORT = 2200

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,11 +72,11 @@ matrix:
     #- python: "2.7"
       #env: MODE=mitogen DISTRO=centos6
     - python: "3.6"
-      env: MODE=mitogen DISTROS=centos7 VER=2.10.0
+      env: MODE=mitogen DISTRO=centos7
     # 2.6 -> 2.7
     # - python: "2.6"
-    #   env: MODE=mitogen DISTROS=centos7 VER=2.10.0
+    #   env: MODE=mitogen DISTRO=centos7
     # 2.6 -> 3.5
     # - python: "2.6"
-    #   env: MODE=mitogen DISTROS=debian-py3 VER=2.10.0
+    #   env: MODE=mitogen DISTRO=debian-py3
     # 3.6 -> 2.6 -- moved to Azure

--- a/tests/doas_test.py
+++ b/tests/doas_test.py
@@ -28,7 +28,7 @@ class ConstructorTest(testlib.RouterMixin, testlib.TestCase):
         self.assertEquals('1', context.call(os.getenv, 'THIS_IS_STUB_DOAS'))
 
 
-# TODO: https://github.com/dw/mitogen/issues/694 they are flaky on python 2.6 MODE=mitogen DISTRO=centos7
+# TODO: https://github.com/dw/mitogen/issues/694 they are flaky on python 2.6 MODE=mitogen DISTROS=centos7
 # class DoasTest(testlib.DockerMixin, testlib.TestCase):
 #     # Only mitogen/debian-test has doas.
 #     mitogen_test_distro = 'debian'


### PR DESCRIPTION
The environment variable `DISTRO` is used to set the target Docker image
used when running the Mitogen unit tests. `DISTROS` is used for the
Ansible integration tests. `VER` sets the version of Ansible that is
installed on the controller.

When `MODE=Mitogen`
- there is no need to set `VER`, because nothing that installs Ansible
- it does not make sense to set `DISTROS`.