### PR TITLE
tests: Add unofficial Tox environments for Ansible tests

### DIFF
--- a/.ci/ansible_tests.py
+++ b/.ci/ansible_tests.py
@@ -66,8 +66,6 @@ with ci_lib.Fold('job_setup'):
         run("sudo apt-get update")
         run("sudo apt-get install -y sshpass")
 
-    run("bash -c 'sudo ln -vfs /usr/lib/python2.7/plat-x86_64-linux-gnu/_sysconfigdata_nd.py /usr/lib/python2.7 || true'")
-    run("bash -c 'sudo ln -vfs /usr/lib/python2.7/plat-x86_64-linux-gnu/_sysconfigdata_nd.py $VIRTUAL_ENV/lib/python2.7 || true'")
 
 with ci_lib.Fold('ansible'):
     playbook = os.environ.get('PLAYBOOK', 'all.yml')

--- a/tests/ansible/integration/playbook_semantics/delegate_to.yml
+++ b/tests/ansible/integration/playbook_semantics/delegate_to.yml
@@ -51,10 +51,14 @@
       shell: whoami > /tmp/delegate_to.yml.txt
       delegate_to: localhost
       become: true
+      tags:
+        - requires_local_sudo
 
     - name: "delegate_to, sudo"
       assert:
         that: "lookup('file', '/tmp/delegate_to.yml.txt') == 'root'"
+      tags:
+        - requires_local_sudo
 
     - name: "delegate_to, sudo"
       file:
@@ -62,6 +66,8 @@
         state: absent
       delegate_to: localhost
       become: true
+      tags:
+        - requires_local_sudo
 
 
     #
@@ -71,10 +77,14 @@
       shell: whoami > /tmp/delegate_to.yml.txt
       connection: local
       become: true
+      tags:
+        - requires_local_sudo
 
     - name: "connection:local, sudo"
       assert:
         that: "lookup('file', '/tmp/delegate_to.yml.txt') == 'root'"
+      tags:
+        - requires_local_sudo
 
     - name: "connection:local, sudo"
       file:
@@ -82,3 +92,5 @@
         state: absent
       connection: local
       become: true
+      tags:
+        - requires_local_sudo

--- a/tests/ansible/regression/issue_152__local_action_wrong_interpreter.yml
+++ b/tests/ansible/regression/issue_152__local_action_wrong_interpreter.yml
@@ -15,7 +15,7 @@
         content: |
           #!/bin/bash
           export CUSTOM_INTERPRETER=1
-          exec python2.7 "$@"
+          exec python "$@"
 
     - custom_python_detect_environment:
       vars:

--- a/tox.ini
+++ b/tox.ini
@@ -1,44 +1,88 @@
+# This file is a local convenience. It is not a substitute for the full CI
+# suite, and does not cover the full range of Python versions for Mitogen.
+
+# I use this on Ubuntu 20.04, with the following additions
+#
+#   sudo add-apt-repository ppa:deadsnakes/ppa
+#   sudo apt update
+#   sudo apt install python3.5 python3.6 python3.7 python3.9 tox libsasl2-dev libldap2-dev libssl-dev ssh-pass
+
+# Last version to support each python version
+#
+#            tox      vir'env  pip      ansible  coverage
+# ========== ======== ======== ======== ======== ========
+# python2.4  1.4      1.8      1.1      ???
+# python2.5  1.6.1    1.9.1    1.3.1    ???
+# python2.6  2.9.1    15.2.0   9.0.3    2.6.20   4.5.4
+
 [tox]
 envlist =
     init,
-    py26,
-    py27,
-    py35,
-    py36,
-    py37,
+    py{27,36,39}-mode_ansible-ansible2.10,
+    py{27,36,39}-mode_mitogen,
+    py{27,36,39}-mode_mitogen-distro_centos7,
     report,
+requires =
+    tox-factor
 
 [testenv]
-usedevelop = True
-deps =
-    -r{toxinidir}/dev_requirements.txt
-    -r{toxinidir}/tests/ansible/requirements.txt
-
+basepython =
+    py26: python2.6
+    py27: python2.7
+    py36: python3.6
+    py37: python3.7
+    py38: python3.8
+    py39: python3.9
+commands_pre =
+    mode_ansible: {toxinidir}/.ci/ansible_install.py
+    mode_debops_common: {toxinidir}/.ci/debops_common_install.py
+    mode_mitogen: {toxinidir}/.ci/mitogen_install.py
 commands =
-    {posargs:bash run_tests}
-whitelist_externals =
-    bash
+    mode_ansible: {toxinidir}/.ci/ansible_tests.py \
+                        --skip-tags requires_local_sudo
+    mode_debops_common: {toxinidir}/.ci/debops_common_tests.py
+    mode_mitogen: {toxinidir}/.ci/mitogen_tests.py
+passenv =
+    HOME
 setenv =
     NOCOVERAGE_ERASE = 1
     NOCOVERAGE_REPORT = 1
+    ansible2.3: VER=2.3.3.0
+    ansible2.4: VER=2.4.6.0
+    ansible2.8: VER=2.8.3
+    ansible2.9: VER=2.9.6
+    ansible2.10: VER=2.10.0
+    distro_centos5: DISTRO=centos5
+    distro_centos6: DISTRO=centos6
+    distro_centos7: DISTRO=centos7
+    distro_debian: DISTRO=debian
+    distro_debianpy3: DISTRO=debian-py3
+    distros_centos5: DISTROS=centos5
+    distros_debian: DISTROS=debian
+    mode_ansible: MODE=ansible
+    mode_debops_common: MODE=debops_common
+    mode_mitogen: MODE=mitogen
+    strategy_linear: STRATEGY=linear
 
 [testenv:init]
+basepython = python3
 commands =
     coverage erase
 deps =
-    coverage
+    coverage==4.5.4
 
 [testenv:report]
+basepython = python3
 commands =
     coverage html
     echo "coverage report is at file://{toxinidir}/htmlcov/index.html"
 deps =
-    coverage
+    coverage==4.5.4
 whitelist_externals =
     echo
 
 [testenv:docs]
-basepython = python
+basepython = python3
 changedir = docs
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html


### PR DESCRIPTION
These are not part of the official testing regime (tests run for pull requests). I find them convenient for local development.

Limitations
- Python 2.7+ only. No Python 2.4, 2.5, or 2.6.
- Requires Pythons pre-installed (e.g. DeadSnakes, pyenv)
- No coverage of alternate controller OS (e.g. MacOS)

The environments tested by default are

- py27-mode_ansible-ansible2.10
- py36-mode_ansible-ansible2.10
- py39-mode_ansible-ansible2.10
- py27-mode_mitogen
- py36-mode_mitogen
- py39-mode_mitogen
- py27-mode_mitogen-distro_centos7
- py36-mode_mitogen-distro_centos7
- py39-mode_mitogen-distro_centos7

fixes #760 