### PR TITLE
Correct version checks of Ansible and Python

### DIFF
--- a/ansible_mitogen/mixins.py
+++ b/ansible_mitogen/mixins.py
@@ -226,7 +226,7 @@ class ActionModuleMixin(ansible.plugins.action.ActionBase):
         with a pipelined call to :func:`ansible_mitogen.target.prune_tree`.
         """
         LOG.debug('_remove_tmp_path(%r)', tmp_path)
-        if tmp_path is None and ansible.__version__ > '2.6':
+        if tmp_path is None and ansible_mitogen.util.ansible_version[:2] > (2, 6):
             tmp_path = self._connection._shell.tmpdir  # 06f73ad578d
         if tmp_path is not None:
             self._connection.get_chain().call_no_reply(
@@ -335,7 +335,7 @@ class ActionModuleMixin(ansible.plugins.action.ActionBase):
     def _set_temp_file_args(self, module_args, wrap_async):
         # Ansible>2.5 module_utils reuses the action's temporary directory if
         # one exists. Older versions error if this key is present.
-        if ansible.__version__ > '2.5':
+        if ansible_mitogen.util.ansible_version[:2] > (2, 5):
             if wrap_async:
                 # Sharing is not possible with async tasks, as in that case,
                 # the directory must outlive the action plug-in.
@@ -346,7 +346,7 @@ class ActionModuleMixin(ansible.plugins.action.ActionBase):
         # If _ansible_tmpdir is unset, Ansible>2.6 module_utils will use
         # _ansible_remote_tmp as the location to create the module's temporary
         # directory. Older versions error if this key is present.
-        if ansible.__version__ > '2.6':
+        if ansible_mitogen.util.ansible_version[:2] > (2, 6):
             module_args['_ansible_remote_tmp'] = (
                 self._connection.get_good_temp_dir()
             )
@@ -393,7 +393,7 @@ class ActionModuleMixin(ansible.plugins.action.ActionBase):
             )
         )
 
-        if tmp and ansible.__version__ < '2.5' and delete_remote_tmp:
+        if tmp and ansible_mitogen.util.ansible_version[:2] < (2, 5) and delete_remote_tmp:
             # Built-in actions expected tmpdir to be cleaned up automatically
             # on _execute_module().
             self._remove_tmp_path(tmp)

--- a/ansible_mitogen/planner.py
+++ b/ansible_mitogen/planner.py
@@ -53,6 +53,7 @@ import mitogen.select
 import ansible_mitogen.loaders
 import ansible_mitogen.parsing
 import ansible_mitogen.target
+import ansible_mitogen.util
 
 
 LOG = logging.getLogger(__name__)
@@ -453,7 +454,7 @@ def py_modname_from_path(name, path):
         except ValueError:
             pass
 
-    if ansible.__version__ < '2.7':
+    if ansible_mitogen.util.ansible_version[:2] < (2, 7):
         return 'ansible_module_' + name
 
     return 'ansible.modules.' + name

--- a/ansible_mitogen/strategy.py
+++ b/ansible_mitogen/strategy.py
@@ -42,6 +42,7 @@ import ansible_mitogen.affinity
 import ansible_mitogen.loaders
 import ansible_mitogen.mixins
 import ansible_mitogen.process
+import ansible_mitogen.util
 
 import ansible
 import ansible.executor.process.worker
@@ -71,23 +72,22 @@ OLD_VERSION_MSG = (
 )
 
 
-def _assert_supported_release():
+def _assert_supported_release(version=ansible_mitogen.util.ansible_version,
+                              version_min=ANSIBLE_VERSION_MIN,
+                              version_max=ANSIBLE_VERSION_MAX,
+                              ):
     """
     Throw AnsibleError with a descriptive message in case of being loaded into
     an unsupported Ansible release.
     """
-    v = ansible.__version__
-    if not isinstance(v, tuple):
-        v = tuple(distutils.version.LooseVersion(v).version)
-
-    if v[:2] < ANSIBLE_VERSION_MIN:
+    if version[:2] < version_min:
         raise ansible.errors.AnsibleError(
-            OLD_VERSION_MSG % (v, ANSIBLE_VERSION_MIN)
+            OLD_VERSION_MSG % (version.join('.'), version_min.join('.'))
         )
 
-    if v[:2] > ANSIBLE_VERSION_MAX:
+    if version[:2] > version_max:
         raise ansible.errors.AnsibleError(
-            NEW_VERSION_MSG % (ansible.__version__, ANSIBLE_VERSION_MAX)
+            NEW_VERSION_MSG % (version.join('.'), version_max.join('.'))
         )
 
 

--- a/ansible_mitogen/target.py
+++ b/ansible_mitogen/target.py
@@ -144,7 +144,7 @@ def subprocess__Popen__close_fds(self, but):
 
 if (
     sys.platform.startswith(u'linux') and
-    sys.version < u'3.0' and
+    sys.version_info[:2] < (3, 0) and
     hasattr(subprocess.Popen, u'_close_fds') and
     not mitogen.is_master
 ):

--- a/ansible_mitogen/util.py
+++ b/ansible_mitogen/util.py
@@ -1,0 +1,15 @@
+from distutils.version import LooseVersion
+
+import ansible
+
+__all__ = [
+    'ansible_version',
+]
+
+if isinstance(ansible.__version__, tuple):
+    ansible_version = ansible.__version__
+else:
+    ansible_version = tuple(LooseVersion(ansible.__version__).version)
+
+del LooseVersion
+del ansible

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,7 @@ This release separates itself from the v0.2.X releases. Ansible's API changed to
 * :gh:issue:`731` ansible 2.10 support
 * :gh:issue:`652` support for ansible collections import hook
 * :gh:issue:`786` correctly compare versions for compatibility checks
+* :gh:issue:`786` Fix kubectl connection plugin under Ansible 2.10
 
 
 v0.2.10 (unreleased)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,7 @@ This release separates itself from the v0.2.X releases. Ansible's API changed to
 
 * :gh:issue:`731` ansible 2.10 support
 * :gh:issue:`652` support for ansible collections import hook
+* :gh:issue:`786` correctly compare versions for compatibility checks
 
 
 v0.2.10 (unreleased)

--- a/tests/ansible/integration/async/result_shell_echo_hi.yml
+++ b/tests/ansible/integration/async/result_shell_echo_hi.yml
@@ -41,6 +41,6 @@
   - assert:
       that:
         - async_out.invocation.module_args.stdin == None
-    when: ansible_version.full > '2.4'
+    when: ansible_version.full is version_compare('2.4', '>', strict=true)
     vars:
       async_out: "{{result.content|b64decode|from_json}}"

--- a/tests/ansible/integration/async/runner_one_job.yml
+++ b/tests/ansible/integration/async/runner_one_job.yml
@@ -40,9 +40,9 @@
       - result1.changed == True
       # ansible/b72e989e1837ccad8dcdc926c43ccbc4d8cdfe44
       - |
-        (ansible_version.full is version('2.8', ">=") and
+        (ansible_version.full is version_compare('2.8', ">=") and
          result1.cmd == "echo alldone;\nsleep 1;\n") or
-        (ansible_version.full is version('2.8', '<') and
+        (ansible_version.full is version_compare('2.8', '<') and
          result1.cmd == "echo alldone;\n sleep 1;")
       - result1.delta|length == 14
       - result1.start|length == 26
@@ -55,9 +55,9 @@
       - result1.stderr_lines == []
       - result1.stdout == "alldone"
       - result1.stdout_lines == ["alldone"]
-    when: ansible_version.full is version('2.8', '>')  # ansible#51393
+    when: ansible_version.full is version_compare('2.8', '>')  # ansible#51393
 
   - assert:
       that:
       - result1.failed == False
-    when: ansible_version.full is version('2.4', '>')
+    when: ansible_version.full is version_compare('2.4', '>')

--- a/tests/ansible/integration/async/runner_two_simultaneous_jobs.yml
+++ b/tests/ansible/integration/async/runner_two_simultaneous_jobs.yml
@@ -60,4 +60,5 @@
   - assert:
       that:
         - result2.stdout == 'im_alive'
-    when: ansible_version.full > '2.8'  # ansible#51393
+    # https://github.com/ansible/ansible/issues/51393
+    when: ansible_version.full is version_compare('2.8', '>', strict=true)

--- a/tests/ansible/integration/connection/reset.yml
+++ b/tests/ansible/integration/connection/reset.yml
@@ -10,10 +10,10 @@
       when: not is_mitogen
 
     - debug: msg="reset.yml skipped on Ansible<2.5.6"
-      when: ansible_version.full < '2.5.6'
+      when: ansible_version.full is version_compare('2.5.6', '<', strict=true)
 
     - meta: end_play
-      when: ansible_version.full < '2.5.6'
+      when: ansible_version.full is version_compare('2.5.6', '<', strict=true)
 
     - custom_python_detect_environment:
       register: out

--- a/tests/ansible/integration/connection/reset_become.yml
+++ b/tests/ansible/integration/connection/reset_become.yml
@@ -6,10 +6,10 @@
   gather_facts: false
   tasks:
   - debug: msg="reset_become.yml skipped on Ansible<2.5.6"
-    when: ansible_version.full < '2.5.6'
+    when: ansible_version.full is version_compare('2.5.6', '<', strict=true)
 
   - meta: end_play
-    when: ansible_version.full < '2.5.6'
+    when: ansible_version.full is version_compare('2.5.6', '<', strict=true)
 
   - name: save pid of the become acct
     custom_python_detect_environment:

--- a/tests/ansible/integration/connection_delegation/delegate_to_template.yml
+++ b/tests/ansible/integration/connection_delegation/delegate_to_template.yml
@@ -20,7 +20,7 @@
       when: not is_mitogen
 
     - meta: end_play
-      when: ansible_version.full < '2.4'
+      when: ansible_version.full is version_compare('2.4', '<', strict=true)
 
     - mitogen_get_stack:
       delegate_to: "{{ physical_host }}"

--- a/tests/ansible/integration/context_service/disconnect_cleanup.yml
+++ b/tests/ansible/integration/context_service/disconnect_cleanup.yml
@@ -9,7 +9,7 @@
     when: not is_mitogen
 
   - meta: end_play
-    when: ansible_version.full < '2.5.6'
+    when: ansible_version.full is version_compare('2.5.6', '<', strict=true)
 
   # Start with a clean slate.
   - mitogen_shutdown_all:

--- a/tests/ansible/integration/interpreter_discovery/ansible_2_8_tests.yml
+++ b/tests/ansible/integration/interpreter_discovery/ansible_2_8_tests.yml
@@ -127,24 +127,24 @@
             assert:
               that:
               - auto_out.ansible_facts.discovered_interpreter_python == '/usr/bin/python3'
-            when: distro == 'fedora' and distro_version is version('23', '>=')
+            when: distro == 'fedora' and distro_version is version_compare('23', '>=')
 
           - name: rhel assertions
             assert:
               that:
               # rhel 6/7
-              - (auto_out.ansible_facts.discovered_interpreter_python == '/usr/bin/python' and distro_version is version('8','<')) or distro_version is version('8','>=')
+              - (auto_out.ansible_facts.discovered_interpreter_python == '/usr/bin/python' and distro_version is version_compare('8','<')) or distro_version is version_compare('8','>=')
               # rhel 8+
-              - (auto_out.ansible_facts.discovered_interpreter_python == '/usr/libexec/platform-python' and distro_version is version('8','>=')) or distro_version is version('8','<')
+              - (auto_out.ansible_facts.discovered_interpreter_python == '/usr/libexec/platform-python' and distro_version is version_compare('8','>=')) or distro_version is version_compare('8','<')
             when: distro in ('redhat', 'centos')
 
           - name: ubuntu assertions
             assert:
               that:
               # ubuntu < 16
-              - (auto_out.ansible_facts.discovered_interpreter_python == '/usr/bin/python' and distro_version is version('16.04','<')) or distro_version is version('16.04','>=')
+              - (auto_out.ansible_facts.discovered_interpreter_python == '/usr/bin/python' and distro_version is version_compare('16.04','<')) or distro_version is version_compare('16.04','>=')
               # ubuntu >= 16
-              - (auto_out.ansible_facts.discovered_interpreter_python == '/usr/bin/python3' and distro_version is version('16.04','>=')) or distro_version is version('16.04','<')
+              - (auto_out.ansible_facts.discovered_interpreter_python == '/usr/bin/python3' and distro_version is version_compare('16.04','>=')) or distro_version is version_compare('16.04','<')
             when: distro == 'ubuntu'
 
           - name: mac assertions

--- a/tests/ansible/integration/runner/crashy_new_style_module.yml
+++ b/tests/ansible/integration/runner/crashy_new_style_module.yml
@@ -14,8 +14,8 @@
         - out.rc == 1
         # ansible/62d8c8fde6a76d9c567ded381e9b34dad69afcd6
         - |
-          (ansible_version.full is version('2.7', '<') and out.msg == "MODULE FAILURE") or
-          (ansible_version.full is version('2.7', '>=') and
+          (ansible_version.full is version_compare('2.7', '<') and out.msg == "MODULE FAILURE") or
+          (ansible_version.full is version_compare('2.7', '>=') and
            out.msg == (
             "MODULE FAILURE\n" +
             "See stdout/stderr for the exact error"

--- a/tests/ansible/integration/runner/custom_perl_json_args_module.yml
+++ b/tests/ansible/integration/runner/custom_perl_json_args_module.yml
@@ -12,7 +12,7 @@
         - out.results[0].input.foo
         - out.results[0].message == 'I am a perl script! Here is my input.'
 
-    - when: ansible_version.full > '2.4'
+    - when: ansible_version.full is version_compare('2.4', '>', strict=true)
       assert:
         that:
         - (not out.changed)

--- a/tests/ansible/integration/runner/custom_perl_want_json_module.yml
+++ b/tests/ansible/integration/runner/custom_perl_want_json_module.yml
@@ -12,7 +12,7 @@
         - out.results[0].input.foo
         - out.results[0].message == 'I am a want JSON perl script! Here is my input.'
 
-    - when: ansible_version.full > '2.4'
+    - when: ansible_version.full is version_compare('2.4', '>', strict=true)
       assert:
         that:
         - (not out.changed)

--- a/tests/ansible/integration/stub_connections/kubectl.yml
+++ b/tests/ansible/integration/stub_connections/kubectl.yml
@@ -8,7 +8,7 @@
     when: not is_mitogen
 
   - meta: end_play
-    when: ansible_version.full < '2.5'
+    when: ansible_version.full is version_compare('2.5', '<', strict=true)
 
   - custom_python_detect_environment:
     vars:

--- a/tests/ansible/lib/modules/custom_python_detect_environment.py
+++ b/tests/ansible/lib/modules/custom_python_detect_environment.py
@@ -26,7 +26,7 @@ except NameError:
 def main():
     module = AnsibleModule(argument_spec={})
     module.exit_json(
-        python_version=sys.version[:3],
+        python_version='%i.%i' % sys.version_info[:2],
         argv=sys.argv,
         __file__=__file__,
         argv_types_correct=all(type(s) is str for s in sys.argv),

--- a/tests/ansible/lib/modules/custom_python_uses_distro.py
+++ b/tests/ansible/lib/modules/custom_python_uses_distro.py
@@ -5,14 +5,16 @@
 import ansible
 from ansible.module_utils.basic import AnsibleModule
 
-if ansible.__version__ > '2.8':
+ansible_version = tuple(int(s) for s in ansible.__version__.split('.'))
+
+if ansible_version[:2] >= (2, 8):
     from ansible.module_utils import distro
 else:
     distro = None
 
 def main():
     module = AnsibleModule(argument_spec={})
-    if ansible.__version__ > '2.8':
+    if ansible_version[:2] >= (2, 8):
         module.exit_json(info=distro.info())
     else:
         module.exit_json(info={'id': None})

--- a/tests/ansible/regression/issue_109__target_has_old_ansible_installed.yml
+++ b/tests/ansible/regression/issue_109__target_has_old_ansible_installed.yml
@@ -7,7 +7,7 @@
   gather_facts: true
   tasks:
     - meta: end_play
-      when: ansible_version.full < '2.6'
+      when: ansible_version.full is version_compare('2.6', '<', strict=true)
 
     # Copy the naughty 'ansible' into place.
     - copy:

--- a/tests/ansible/regression/issue_590__sys_modules_crap.yml
+++ b/tests/ansible/regression/issue_590__sys_modules_crap.yml
@@ -2,7 +2,7 @@
 - hosts: test-targets
   tasks:
   - meta: end_play
-    when: ansible_version.full < '2.8'
+    when: ansible_version.full is version_compare('2.8', '<', strict=true)
 
   - custom_python_uses_distro:
     register: out


### PR DESCRIPTION
Checks were performed using character by character string comparisons. This gives incorrect results when checking Ansible 2.10, because '2.10' < '2.9'.

Fixes #786 