### PR TITLE
tests: Tag resource intensive tasks, to skip when strategy=linear

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -30,6 +30,7 @@ jobs:
         MODE: localhost_ansible
         VER: 2.10.0
         STRATEGY: linear
+        ANSIBLE_SKIP_TAGS: resource_intensive
 
 
 - job: Linux

--- a/tests/ansible/all.yml
+++ b/tests/ansible/all.yml
@@ -1,3 +1,4 @@
+- include: setup/all.yml
 - include: regression/all.yml
 - include: integration/all.yml
 

--- a/tests/ansible/bench/file_transfer.yml
+++ b/tests/ansible/bench/file_transfer.yml
@@ -66,3 +66,6 @@
     copy:
       src: /tmp/bigbigfile.in
       dest: /tmp/bigbigfile.out
+
+  tags:
+  - resource_intensive

--- a/tests/ansible/bench/includes.yml
+++ b/tests/ansible/bench/includes.yml
@@ -2,3 +2,5 @@
   tasks:
   - include_tasks: _includes.yml
     with_sequence: start=1 end=1000
+  tags:
+    - resource_intensive

--- a/tests/ansible/bench/loop-100-copies.yml
+++ b/tests/ansible/bench/loop-100-copies.yml
@@ -24,3 +24,8 @@
       mode: 0644
     with_filetree: /tmp/filetree.in
     when: item.state == 'file'
+    loop_control:
+      label: "/tmp/filetree.out/{{ item.path }}"
+
+  tags:
+    - resource_intensive

--- a/tests/ansible/bench/loop-100-items.yml
+++ b/tests/ansible/bench/loop-100-items.yml
@@ -8,3 +8,5 @@
   tasks:
     - command: hostname
       with_sequence: start=1 end="{{end|default(100)}}"
+  tags:
+    - resource_intensive

--- a/tests/ansible/bench/loop-100-tasks.yml
+++ b/tests/ansible/bench/loop-100-tasks.yml
@@ -110,3 +110,5 @@
     - command: hostname
     - command: hostname
     - command: hostname
+  tags:
+    - resource_intensive

--- a/tests/ansible/regression/issue_140__thread_pileup.yml
+++ b/tests/ansible/regression/issue_140__thread_pileup.yml
@@ -29,3 +29,8 @@
       mode: 0644
     with_filetree: /tmp/filetree.in
     when: item.state == 'file'
+    loop_control:
+      label: "/tmp/filetree.out/{{ item.path }}"
+
+  tags:
+  - resource_intensive

--- a/tests/ansible/setup/all.yml
+++ b/tests/ansible/setup/all.yml
@@ -1,0 +1,1 @@
+- include: report.yml

--- a/tests/ansible/setup/report.yml
+++ b/tests/ansible/setup/report.yml
@@ -1,0 +1,8 @@
+- name: Report runtime settings
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - debug: {var: ansible_forks}
+    - debug: {var: ansible_run_tags}
+    - debug: {var: ansible_skip_tags}
+    - debug: {var: ansible_version.full}

--- a/tests/ansible/soak/file_service.yml
+++ b/tests/ansible/soak/file_service.yml
@@ -4,3 +4,5 @@
       content: "{% for x in range(126977) %}x{% endfor %}"
   - include: _file_service_loop.yml
     with_sequence: start=1 end=100
+  tags:
+    - resource_intensive


### PR DESCRIPTION
The ansible_mitogen test suite takes over an hour when Ansible is not
accelerated by Mitogen. This change aims to reduce that by skipping
tests with a large number of iterations when the linear strategy is
chosen.