### PR TITLE
Handle condition going from privileged to non-privileged user in whic…

### DIFF
--- a/ansible_mitogen/runner.py
+++ b/ansible_mitogen/runner.py
@@ -378,10 +378,15 @@ class Runner(object):
         """
         For situations like sudo to a non-privileged account, CWD could be
         $HOME of the old account, which could have mode go=, which means it is
-        impossible to restore the old directory, so don't even try.
+        impossible to restore the old directory. Fallback to a neutral temp if so.
         """
         if self.cwd:
-            os.chdir(self.cwd)
+            try:
+                os.chdir(self.cwd)
+            except OSError:
+                LOG.debug('%r: could not CHDIR to %r fallback to %r',
+                          self, self.cwd, self.good_temp_dir)
+                os.chdir(self.good_temp_dir)
 
     def _setup_environ(self):
         """

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,7 @@ v0.3.0 (unreleased)
 This release separates itself from the v0.2.X releases. Ansible's API changed too much to support backwards compatibility so from now on, v0.2.X releases will be for Ansible < 2.10 and v0.3.X will be for Ansible 2.10+.
 `See here for details <https://github.com/dw/mitogen pull/715#issuecomment-750697248>`_.
 
+* :gh:issue:`636` os.chdir fails if the sudo/become user lacks adequate permissions to chdir prior to task
 * :gh:issue:`731` ansible 2.10 support
 * :gh:issue:`652` support for ansible collections import hook
 
@@ -30,6 +31,7 @@ This release separates itself from the v0.2.X releases. Ansible's API changed to
 v0.2.10 (unreleased)
 --------------------
 
+* :gh:issue:`636` os.chdir fails if the sudo/become user lacks adequate permissions to chdir prior to task
 * :gh:issue:`597` mitogen does not support Ansible 2.8 Python interpreter detection
 * :gh:issue:`655` wait_for_connection gives errors
 * :gh:issue:`672` cannot perform relative import error


### PR DESCRIPTION
…h the cwd disables descent.

Fall back to Mitogen's temporary directory. Related to #636.


Allows Mitogen to fallback to a safe temporary directory when become is used and become_user cannot use the cwd. For example, fixes the following code assuming directory of `playbook_dir` is owned by root with permission 0700.

```yaml
- hosts: localhost
  gather_facts: no
  tasks:
    - stat: path="{{ playbook_dir }}"
    - command: cd {{ playbook_dir | quote }}
    - command: sudo -u nobody cd {{ playbook_dir | quote }}
      ignore_errors: True
      args:
        warn: False
    - stat: path="{{ playbook_dir }}"
      become: True
      become_user: nobody
```

Previously, os.chdir fails:

```
The full traceback is:
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/ansible/executor/task_executor.py", line 147, in run
    res = self._execute()
  File "/usr/lib/python3.6/site-packages/ansible/executor/task_executor.py", line 665, in _execute
    result = self._handler.run(task_vars=variables)
  File "/root/mitogen/build/lib/ansible_mitogen/mixins.py", line 142, in run
    return super(ActionModuleMixin, self).run(tmp, task_vars)
  File "/usr/lib/python3.6/site-packages/ansible/plugins/action/normal.py", line 47, in run
    result = merge_hash(result, self._execute_module(task_vars=task_vars, wrap_async=wrap_async))
  File "/root/mitogen/build/lib/ansible_mitogen/mixins.py", line 392, in _execute_module
    timeout_secs=self.get_task_timeout_secs(),
  File "/root/mitogen/build/lib/ansible_mitogen/planner.py", line 599, in invoke
    kwargs=planner.get_kwargs(),
  File "/root/mitogen/build/lib/ansible_mitogen/connection.py", line 451, in call
    return self._rethrow(recv)
  File "/root/mitogen/build/lib/ansible_mitogen/connection.py", line 437, in _rethrow
    return recv.get().unpickle()
  File "/root/mitogen/build/lib/mitogen/core.py", line 963, in unpickle
    raise obj
mitogen.core.CallError: builtins.PermissionError: [Errno 13] Permission denied: '/usr/local/apnscp/resources/playbooks'
  File "<stdin>", line 3676, in _dispatch_one
  File "master:/root/mitogen/build/lib/ansible_mitogen/target.py", line 422, in run_module
    return impl.run()
  File "master:/root/mitogen/build/lib/ansible_mitogen/runner.py", line 440, in run
    self.setup()
  File "master:/root/mitogen/build/lib/ansible_mitogen/runner.py", line 851, in setup
    super(NewStyleRunner, self).setup()
  File "master:/root/mitogen/build/lib/ansible_mitogen/runner.py", line 623, in setup
    super(ProgramRunner, self).setup()
  File "master:/root/mitogen/build/lib/ansible_mitogen/runner.py", line 374, in setup
    self._setup_cwd()
  File "master:/root/mitogen/build/lib/ansible_mitogen/runner.py", line 384, in _setup_cwd
    os.chdir(self.cwd)

fatal: [localhost]: FAILED! => 
  msg: Unexpected failure during module execution.
  stdout: ''
```

With this change it succeeds falling back to /var/tmp restoring normal Ansible operation. 
```
The full traceback is:
  File "master:/usr/lib/python3.6/site-packages/ansible/modules/files/stat.py", line 464, in main
fatal: [localhost]: FAILED! => changed=false 
  invocation:
    module_args:
      checksum_algorithm: sha1
      follow: false
      get_attributes: true
      get_checksum: true
      get_md5: false
      get_mime: true
      path: /usr/local/apnscp/resources/playbooks
  msg: Permission denied
```

Debug log from the task.
```
[mux  3057890] 14:13:52.493340 D mitogen.[fork.3058008]: Parent is context 4 (parent); my ID is 1006
[mux  3057890] 14:13:52.493396 D mitogen.[fork.3058008]: pid:3058008 ppid:3057993 uid:65534/65534, gid:65534/65534 host:'c8-test'
[mux  3057890] 14:13:52.493452 D mitogen.[fork.3058008]: Recovered sys.executable: '/usr/bin/python3.6'
[mux  3057890] 14:13:52.498076 D mitogen.service.[local.3057927.sudo.nobody]: PushFileService().store_and_forward('/usr/lib/python3.6/site-packages/ansible/modules/files/stat.py', [blob: 19038 bytes], Context(4, 'sudo.nobody')) 'mitogen.Pool.5940.0'
[mux  3057890] 14:13:52.504938 D mitogen.service.[local.3057927.sudo.nobody]: Pool(5940, size=2, th='MainThread'): initialized
[mux  3057890] 14:13:52.505143 D mitogen.[local.3057927.sudo.nobody]: Dispatcher: dispatching ('c8-test-3057968-7f5a555b4b80-77a7276d47', 'ansible_mitogen.target', None, 'run_module', (), Kwargs({'kwargs': {'runner_name': 'NewStyleRunner', 'module': 'stat', 'path': '/usr/lib/python3.6/site-packages/ansible/modules/files/stat.py', 'json_args': '{"path": "/usr/local/apnscp/resources/playbooks", "_ansible_check_mode": false, "_ansible_no_log": false, "_ansible_debug": false, "_ansible_diff": false, "_ansible_verbosity": 3, "_ansible_version": "2.9.17", "_ansible_module_name": "stat", "_ansible_syslog_facility": "LOG_USER", "_ansible_selinux_special_fs": ["fuse", "nfs", "vboxsf", "ramfs", "9p", "vfat"], "_ansible_string_conversion_action": "warn", "_ansible_socket": null, "_ansible_shell_executable": "/bin/sh", "_ansible_keep_remote_files": false, "_ansible_tmpdir": null, "_ansible_remote_tmp": "/var/tmp"}', 'env': {}, 'interpreter_fragment': None, 'is_python': None, 'module_map': {'builtin': ['ansible.module_utils._text', 'ansible.module_utils.basic', 'ansible.module_utils.common', 'ansible.module_utils.common._collections_compat', 'ansible.module_utils.common._json_compat', 'ansible.module_utils.common._utils', 'ansible.module_utils.common.collections', 'ansible.module_utils.common.file', 'ansible.module_utils.common.parameters', 'ansible.module_utils.common.process', 'ansible.module_utils.common.sys_info', 'ansible.module_utils.common.text', 'ansible.module_utils.common.text.converters', 'ansible.module_utils.common.text.formatters', 'ansible.module_utils.common.validation', 'ansible.module_utils.compat', 'ansible.module_utils.compat._selectors2', 'ansible.module_utils.compat.selectors', 'ansible.module_utils.distro', 'ansible.module_utils.distro._distro', 'ansible.module_utils.parsing', 'ansible.module_utils.parsing.convert_bool', 'ansible.module_utils.pycompat24', 'ansible.module_utils.six'], 'custom': []}, 'py_module_name': 'ansible.modules.files.stat', 'good_temp_dir': '/var/tmp', 'cwd': '/usr/local/apnscp/resources/playbooks', 'extra_env': {}, 'emulate_tty': True, 'service_context': Context(0, None)}}))
[mux  3057890] 14:13:52.505239 D ansible_mitogen.runner.[local.3057927.sudo.nobody]: <ansible_mitogen.runner.NewStyleRunner object at 0x7f41cc4d5a58>: could not CHDIR to '/usr/local/apnscp/resources/playbooks' fallback to '/var/tmp'
```

I believe a test case wouldn't hurt; however, I'm not terribly great with Python and wouldn't know where to begin with creating a non-privileged user or skipping the test if "become" is unavailable.