### PR TITLE
Add mitogen_container_name variable.

### DIFF
--- a/ansible_mitogen/connection.py
+++ b/ansible_mitogen/connection.py
@@ -182,7 +182,10 @@ def _connect_docker(spec):
         'method': 'docker',
         'kwargs': {
             'username': spec.remote_user(),
-            'container': spec.remote_addr(),
+            'container': (
+                spec.mitogen_container_name() or
+                spec.remote_addr()
+            ),
             'python_path': spec.python_path(rediscover_python=True),
             'connect_timeout': spec.ansible_ssh_timeout() or spec.timeout(),
             'remote_name': get_remote_name(spec),
@@ -197,7 +200,10 @@ def _connect_kubectl(spec):
     return {
         'method': 'kubectl',
         'kwargs': {
-            'pod': spec.remote_addr(),
+            'pod': (
+                spec.mitogen_container_name() or
+                spec.remote_addr()
+            ),
             'python_path': spec.python_path(),
             'connect_timeout': spec.ansible_ssh_timeout() or spec.timeout(),
             'kubectl_path': spec.mitogen_kubectl_path(),
@@ -215,7 +221,10 @@ def _connect_jail(spec):
         'method': 'jail',
         'kwargs': {
             'username': spec.remote_user(),
-            'container': spec.remote_addr(),
+            'container': (
+                spec.mitogen_container_name() or
+                spec.remote_addr()
+            ),
             'python_path': spec.python_path(),
             'connect_timeout': spec.ansible_ssh_timeout() or spec.timeout(),
             'remote_name': get_remote_name(spec),
@@ -230,7 +239,10 @@ def _connect_lxc(spec):
     return {
         'method': 'lxc',
         'kwargs': {
-            'container': spec.remote_addr(),
+            'container': (
+                spec.mitogen_container_name() or
+                spec.remote_addr()
+            ),
             'python_path': spec.python_path(),
             'lxc_attach_path': spec.mitogen_lxc_attach_path(),
             'connect_timeout': spec.ansible_ssh_timeout() or spec.timeout(),
@@ -246,7 +258,10 @@ def _connect_lxd(spec):
     return {
         'method': 'lxd',
         'kwargs': {
-            'container': spec.remote_addr(),
+            'container': (
+                spec.mitogen_container_name() or
+                spec.remote_addr()
+            ),
             'python_path': spec.python_path(),
             'lxc_path': spec.mitogen_lxc_path(),
             'connect_timeout': spec.ansible_ssh_timeout() or spec.timeout(),
@@ -269,7 +284,10 @@ def _connect_setns(spec, kind=None):
     return {
         'method': 'setns',
         'kwargs': {
-            'container': spec.remote_addr(),
+            'container': (
+                spec.mitogen_container_name() or
+                spec.remote_addr()
+            ),
             'username': spec.remote_user(),
             'python_path': spec.python_path(),
             'kind': kind or spec.mitogen_kind(),

--- a/ansible_mitogen/transport_config.py
+++ b/ansible_mitogen/transport_config.py
@@ -379,6 +379,13 @@ class Spec(with_metaclass(abc.ABCMeta, object)):
         """
 
     @abc.abstractmethod
+    def mitogen_container_name(self):
+        """
+        Highest precedence variable for specifying the name of a container to
+        connect to.
+        """
+
+    @abc.abstractmethod
     def extra_args(self):
         """
         Connection-specific arguments.
@@ -541,6 +548,9 @@ class PlayContextSpec(Spec):
 
     def mitogen_ssh_compression(self):
         return self._connection.get_task_var('mitogen_ssh_compression')
+
+    def mitogen_container_name(self):
+        return self._connection.get_task_var('mitogen_container_name')
 
     def extra_args(self):
         return self._connection.get_extra_args()
@@ -777,6 +787,9 @@ class MitogenViaSpec(Spec):
 
     def mitogen_ssh_compression(self):
         return self._host_vars.get('mitogen_ssh_compression')
+
+    def mitogen_container_name(self):
+        return self._host_vars.get('mitogen_container_name')
 
     def extra_args(self):
         return []  # TODO


### PR DESCRIPTION
Allow the container name to be specified over ansible hostname.
Applying changes as per upstream mitogen repo, branch issue510.
https://github.com/dw/mitogen/commit/01840fd0b0c4f152c9a9ebc72d14b7e5fd9de701


Thanks for creating a PR! Here's a quick checklist to pay attention to:

* Please add an entry to docs/changelog.rst as appropriate.

* Has some new parameter been added or semantics modified somehow? Please
  ensure relevant documentation is updated in docs/ansible.rst and
  docs/api.rst.

* If it's for new functionality, is there at least a basic test in either
  tests/ or tests/ansible/ covering it?

* If it's for a new connection method, please try to stub out the
  implementation as in tests/data/stubs/, so that construction can be tested
  without having a working configuration.

