### PR TITLE
increase length check in _unpickle_context

### DIFF
--- a/mitogen/core.py
+++ b/mitogen/core.py
@@ -2309,7 +2309,7 @@ class Context(object):
 def _unpickle_context(context_id, name, router=None):
     if not (isinstance(context_id, (int, long)) and context_id >= 0 and (
         (name is None) or
-        (isinstance(name, UnicodeType) and len(name) < 100))
+        (isinstance(name, UnicodeType) and len(name) < 519))
     ):
         raise TypeError('cannot unpickle Context: bad input')
 


### PR DESCRIPTION
The length check len(name) < 100 fails if longer hostnames are used.
A hostname may be 255 bytes long, in addition with ssh as transport and if a bastion host is used this may result in a 518 character long string (ssh.<bastionhost>.ssh.<targethost> ~max 4 + 255 +4 + 255 ).
So the length check should be increased to allow max 518 character.


Thanks for creating a PR! Here's a quick checklist to pay attention to:

* Please add an entry to docs/changelog.rst as appropriate.

* Has some new parameter been added or semantics modified somehow? Please
  ensure relevant documentation is updated in docs/ansible.rst and
  docs/api.rst.

* If it's for new functionality, is there at least a basic test in either
  tests/ or tests/ansible/ covering it?

* If it's for a new connection method, please try to stub out the
  implementation as in tests/data/stubs/, so that construction can be tested
  without having a working configuration.

