### PR TITLE
tests: Support multi-word cpusets

### DIFF
--- a/tests/ansible/tests/affinity_test.py
+++ b/tests/ansible/tests/affinity_test.py
@@ -179,7 +179,8 @@ class LinuxPolicyTest(testlib.TestCase):
         try:
             for line in fp:
                 if line.startswith('Cpus_allowed'):
-                    return int(line.split()[1], 16)
+                    mask = line.split()[1].replace(',', '')
+                    return int(mask, 16)
         finally:
             fp.close()
 


### PR DESCRIPTION
From cpuset(7):

> For masks longer than one word, a comma separator is used between words. Words are displayed in big-endian order, which has the most significant bit first. The hex digits within a word are also in big-endian order.
