### PR TITLE
mitogen.utils.with_router wrapper copies the docstring in addition to the name

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,7 @@ This release separates itself from the v0.2.X releases. Ansible's API changed to
 * :gh:issue:`770` better check for supported Ansible version
 * :gh:issue:`731` ansible 2.10 support
 * :gh:issue:`652` support for ansible collections import hook
+* :gh:issue:`836` mitogen.utils.with_router wrapper copies the docstring in addition to the name.
 
 
 v0.2.10 (unreleased)

--- a/mitogen/utils.py
+++ b/mitogen/utils.py
@@ -175,6 +175,8 @@ def with_router(func):
     """
     def wrapper(*args, **kwargs):
         return run_with_router(func, *args, **kwargs)
+
+    wrapper.__doc__ = func.__doc__
     if mitogen.core.PY3:
         wrapper.func_name = func.__name__
     else:


### PR DESCRIPTION
Fixes #836.