### PR TITLE
Fix issue 827 (collections import)

### DIFF
--- a/ansible_mitogen/planner.py
+++ b/ansible_mitogen/planner.py
@@ -41,6 +41,7 @@ import json
 import logging
 import os
 import random
+import re
 
 from ansible.executor import module_common
 from ansible.collections.list import list_collection_dirs
@@ -297,11 +298,11 @@ class NewStylePlanner(ScriptPlanner):
     preprocessing the module.
     """
     runner_name = 'NewStyleRunner'
-    marker = b'from ansible.module_utils.'
+    MARKER = re.compile(b'from ansible(?:_collections|\.module_utils)\.')
 
     @classmethod
     def detect(cls, path, source):
-        return cls.marker in source
+        return cls.MARKER.search(source) != None
 
     def _get_interpreter(self):
         return None, None

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,7 @@ v0.3.0 (unreleased)
 This release separates itself from the v0.2.X releases. Ansible's API changed too much to support backwards compatibility so from now on, v0.2.X releases will be for Ansible < 2.10 and v0.3.X will be for Ansible 2.10+.
 `See here for details <https://github.com/dw/mitogen pull/715#issuecomment-750697248>`_.
 
+* :gh:issue:`827` NewStylePlanner: detect `ansible_collections` imports
 * :gh:issue:`770` better check for supported Ansible version
 * :gh:issue:`731` ansible 2.10 support
 * :gh:issue:`652` support for ansible collections import hook


### PR DESCRIPTION
some ansible collections write their own module classes derived from
ansible.module_utils.basic.AnsibleModule, thus lacking that import
in the plugin file. NewStylePlanner was unable to detect these plugins
as Ansiballz.

This PR extends the search pattern for NewStylePlanner to also
detect ansible_collections imports.
