### PR TITLE
Fix for load_plugins() called twice error with dnf

### DIFF
--- a/ansible_mitogen/planner.py
+++ b/ansible_mitogen/planner.py
@@ -321,6 +321,7 @@ class NewStylePlanner(ScriptPlanner):
     ALWAYS_FORK_MODULES = frozenset([
         'dnf',  # issue #280; py-dnf/hawkey need therapy
         'firewalld',  # issue #570: ansible module_utils caches dbus conn
+        'ansible.legacy.dnf',  # issue #776
     ])
 
     def should_fork(self):


### PR DESCRIPTION
Fix `load_plugins() called twice` error when using dnf module with Ansible 2.10. Fixes issue #776.

