### PR TITLE
tests: Authenticate to AWS Elastic Container Registry for `docker pull`

### DIFF
--- a/.ci/ansible_install.py
+++ b/.ci/ansible_install.py
@@ -13,12 +13,15 @@ batches = [
             '-r tests/ansible/requirements.txt',
         # encoding is required for installing ansible 2.10 with pip2, otherwise we get a UnicodeDecode error
         'LC_CTYPE=en_US.UTF-8 LANG=en_US.UTF-8 pip install -q ansible=={0}'.format(ci_lib.ANSIBLE_VERSION)
+    ],
+    [
+        'aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws',
     ]
 ]
 
-batches.append(ci_lib.throttle(
+batches[-1].extend([
     'docker pull %s' % (ci_lib.image_for_distro(distro),)
     for distro in ci_lib.DISTROS
-))
+])
 
 ci_lib.run_batches(batches)

--- a/.ci/azure-pipelines-steps.yml
+++ b/.ci/azure-pipelines-steps.yml
@@ -18,6 +18,10 @@ steps:
 
 - script: .ci/$(MODE)_install.py
   displayName: "Run $(MODE)_install.py"
+  env:
+    AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
+    AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
+    AWS_DEFAULT_REGION: $(AWS_DEFAULT_REGION)
 
 - script: .ci/$(MODE)_tests.py
   displayName: "Run $(MODE)_tests.py"

--- a/.ci/debops_common_install.py
+++ b/.ci/debops_common_install.py
@@ -13,6 +13,7 @@ ci_lib.run_batches([
         'pip install -qqq debops[ansible]==2.1.2 ansible==%s' % ci_lib.ANSIBLE_VERSION,
     ],
     [
+        'aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws',
         'docker pull %s' % (ci_lib.image_for_distro('debian'),),
     ],
 ])

--- a/.ci/mitogen_install.py
+++ b/.ci/mitogen_install.py
@@ -11,6 +11,7 @@ batches = [
 
 if ci_lib.have_docker():
     batches.append([
+        'aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws',
         'docker pull %s' % (ci_lib.image_for_distro(ci_lib.DISTRO),),
     ])
 

--- a/.ci/mitogen_py24_install.py
+++ b/.ci/mitogen_py24_install.py
@@ -4,6 +4,7 @@ import ci_lib
 
 batches = [
     [
+        'aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws',
         'docker pull %s' % (ci_lib.image_for_distro(ci_lib.DISTRO),),
     ],
     [

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ cache:
   - /home/travis/virtualenv
 
 install:
+- if ! [ -x "$(command -v aws)" ]; then curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" ; unzip awscliv2.zip ; sudo ./aws/install ; fi
 - pip install -U pip==20.2.1
 - .ci/${MODE}_install.py
 


### PR DESCRIPTION
This should increase the rate limit from 1/s to 10/s. AWS
credentials are obtained from environment variables in Azure
pipelines, or the default AWS CLI profile.

https://docs.aws.amazon.com/AmazonECR/latest/public/public-service-quotas.html
https://docs.aws.amazon.com/AmazonECR/latest/public/public-registries.html#public-registry-auth
https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html


Thanks for creating a PR! Here's a quick checklist to pay attention to:

* Please add an entry to docs/changelog.rst as appropriate.

* Has some new parameter been added or semantics modified somehow? Please
  ensure relevant documentation is updated in docs/ansible.rst and
  docs/api.rst.

* If it's for new functionality, is there at least a basic test in either
  tests/ or tests/ansible/ covering it?

* If it's for a new connection method, please try to stub out the
  implementation as in tests/data/stubs/, so that construction can be tested
  without having a working configuration.

