### PR TITLE
Support for ansible-core 2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
 - MODE=${MODE} .ci/travis.sh
 
 # To avoid matrix explosion, just test against oldest->newest and
-# newest->oldest in various configuartions.
+# newest->oldest in various configurations.
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ cache:
 
 install:
 - if ! [ -x "$(command -v aws)" ]; then curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" ; unzip awscliv2.zip ; sudo ./aws/install ; fi
-- pip install -U pip==20.2.1
+- pip install -U pip==21.3
 - .ci/${MODE}_install.py
 
 # Travis has a 4MB log limit (https://github.com/travis-ci/travis-ci/issues/1382), but verbose Mitogen logs run larger than that

--- a/ansible_mitogen/loaders.py
+++ b/ansible_mitogen/loaders.py
@@ -45,7 +45,7 @@ __all__ = [
 import ansible
 
 ANSIBLE_VERSION_MIN = (2, 10)
-ANSIBLE_VERSION_MAX = (2, 10)
+ANSIBLE_VERSION_MAX = (2, 11)
 
 NEW_VERSION_MSG = (
     "Your Ansible version (%s) is too recent. The most recent version\n"

--- a/ansible_mitogen/transport_config.py
+++ b/ansible_mitogen/transport_config.py
@@ -464,6 +464,7 @@ class PlayContextSpec(Spec):
         )
 
     def ssh_args(self):
+        variables = self._task_vars["vars"].get("vars", {})
         return [
             mitogen.core.to_text(term)
             for s in (
@@ -471,19 +472,19 @@ class PlayContextSpec(Spec):
                     "ssh_args",
                     plugin_type="connection",
                     plugin_name="ssh",
-                    variables=self._task_vars["vars"]["vars"],
+                    variables=variables,
                 ),
                 C.config.get_config_value(
                     "ssh_common_args",
                     plugin_type="connection",
                     plugin_name="ssh",
-                    variables=self._task_vars["vars"]["vars"],
+                    variables=variables,
                 ),
                 C.config.get_config_value(
                     "ssh_extra_args",
                     plugin_type="connection",
                     plugin_name="ssh",
-                    variables=self._task_vars["vars"]["vars"],
+                    variables=variables,
                 ),
             )
             for term in ansible.utils.shlex.shlex_split(s or '')

--- a/ansible_mitogen/transport_config.py
+++ b/ansible_mitogen/transport_config.py
@@ -464,7 +464,7 @@ class PlayContextSpec(Spec):
         )
 
     def ssh_args(self):
-        variables = self._task_vars["vars"].get("vars", {})
+        variables = self._task_vars.get("vars", {})
         return [
             mitogen.core.to_text(term)
             for s in (

--- a/ansible_mitogen/transport_config.py
+++ b/ansible_mitogen/transport_config.py
@@ -451,7 +451,7 @@ class PlayContextSpec(Spec):
         return self._play_context.private_key_file
 
     def ssh_executable(self):
-        return self._play_context.ssh_executable
+        return C.config.get_config_value("ssh_executable", plugin_type="connection", plugin_name="ssh")
 
     def timeout(self):
         return self._play_context.timeout
@@ -467,9 +467,9 @@ class PlayContextSpec(Spec):
         return [
             mitogen.core.to_text(term)
             for s in (
-                getattr(self._play_context, 'ssh_args', ''),
-                getattr(self._play_context, 'ssh_common_args', ''),
-                getattr(self._play_context, 'ssh_extra_args', '')
+                C.config.get_config_value("ssh_args", plugin_type="connection", plugin_name="ssh"),
+                C.config.get_config_value("ssh_common_args", plugin_type="connection", plugin_name="ssh"),
+                C.config.get_config_value("ssh_extra_args", plugin_type="connection", plugin_name="ssh")
             )
             for term in ansible.utils.shlex.shlex_split(s or '')
         ]

--- a/ansible_mitogen/transport_config.py
+++ b/ansible_mitogen/transport_config.py
@@ -467,9 +467,24 @@ class PlayContextSpec(Spec):
         return [
             mitogen.core.to_text(term)
             for s in (
-                C.config.get_config_value("ssh_args", plugin_type="connection", plugin_name="ssh"),
-                C.config.get_config_value("ssh_common_args", plugin_type="connection", plugin_name="ssh"),
-                C.config.get_config_value("ssh_extra_args", plugin_type="connection", plugin_name="ssh")
+                C.config.get_config_value(
+                    "ssh_args",
+                    plugin_type="connection",
+                    plugin_name="ssh",
+                    variables=self._task_vars["vars"],
+                ),
+                C.config.get_config_value(
+                    "ssh_common_args",
+                    plugin_type="connection",
+                    plugin_name="ssh",
+                    variables=self._task_vars["vars"],
+                ),
+                C.config.get_config_value(
+                    "ssh_extra_args",
+                    plugin_type="connection",
+                    plugin_name="ssh",
+                    variables=self._task_vars["vars"],
+                ),
             )
             for term in ansible.utils.shlex.shlex_split(s or '')
         ]

--- a/ansible_mitogen/transport_config.py
+++ b/ansible_mitogen/transport_config.py
@@ -471,19 +471,19 @@ class PlayContextSpec(Spec):
                     "ssh_args",
                     plugin_type="connection",
                     plugin_name="ssh",
-                    variables=self._task_vars["vars"],
+                    variables=self._task_vars["vars"]["vars"],
                 ),
                 C.config.get_config_value(
                     "ssh_common_args",
                     plugin_type="connection",
                     plugin_name="ssh",
-                    variables=self._task_vars["vars"],
+                    variables=self._task_vars["vars"]["vars"],
                 ),
                 C.config.get_config_value(
                     "ssh_extra_args",
                     plugin_type="connection",
                     plugin_name="ssh",
-                    variables=self._task_vars["vars"],
+                    variables=self._task_vars["vars"]["vars"],
                 ),
             )
             for term in ansible.utils.shlex.shlex_split(s or '')

--- a/docs/ansible_detailed.rst
+++ b/docs/ansible_detailed.rst
@@ -11,7 +11,7 @@ Mitogen for Ansible
 module runtime for `Ansible`_. Requiring minimal configuration changes, it
 updates Ansible's slow and wasteful shell-centric implementation with
 pure-Python equivalents, invoked via highly efficient remote procedure calls to
-persistent interpreters tunnelled over SSH. No changes are required to target
+persistent interpreters tunneled over SSH. No changes are required to target
 hosts.
 
 The extension is considered stable and real-world use is encouraged.
@@ -145,9 +145,9 @@ Testimonials
 Noteworthy Differences
 ----------------------
 
-* Ansible 2.3-2.9 are supported along with Python 2.6, 2.7, 3.6 and 3.7. Verify
-  your installation is running one of these versions by checking ``ansible
-  --version`` output.
+* Ansible 2.3-2.11 are supported along with Python 2.6, 2.7, 3.6, 3.7, 3.8, and
+  3.9. Verify your installation is running one of these versions by checking
+  ``ansible --version`` output.
 
 * The ``raw`` action executes as a regular Mitogen connection, which requires
   Python on the target, precluding its use for installing Python. This will be
@@ -176,7 +176,7 @@ Noteworthy Differences
 * The ``doas``, ``su`` and ``sudo`` become methods are available. File bugs to
   register interest in more.
 
-* The ``sudo`` comands executed differ slightly compared to Ansible. In some
+* The ``sudo`` commands executed differ slightly compared to Ansible. In some
   cases where the target has a ``sudo`` configuration that restricts the exact
   commands allowed to run, it may be necessary to add a ``sudoers`` rule like:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,7 @@ v0.3.0 (unreleased)
 This release separates itself from the v0.2.X releases. Ansible's API changed too much to support backwards compatibility so from now on, v0.2.X releases will be for Ansible < 2.10 and v0.3.X will be for Ansible 2.10+.
 `See here for details <https://github.com/dw/mitogen pull/715#issuecomment-750697248>`_.
 
+* :gh:issue:`841` ansible 2.11 support
 * :gh:issue:`827` NewStylePlanner: detect `ansible_collections` imports
 * :gh:issue:`770` better check for supported Ansible version
 * :gh:issue:`731` ansible 2.10 support

--- a/run_tests
+++ b/run_tests
@@ -36,7 +36,7 @@ if [ ! "$NOCOVERAGE_ERASE" ]; then
     coverage erase
 fi
 
-# First run overwites coverage output.
+# First run overwrites coverage output.
 [ "$SKIP_MITOGEN" ] || {
     if [ ! "$NOCOVERAGE" ]; then
         coverage run -a "${UNIT2}" discover \

--- a/tests/ansible/integration/become/sudo_flags_failure.yml
+++ b/tests/ansible/integration/become/sudo_flags_failure.yml
@@ -19,5 +19,6 @@
             ('sudo: no such option: --derps' in out.msg) or
             ("sudo: invalid option -- '-'" in out.module_stderr) or
             ("sudo: unrecognized option `--derps'" in out.module_stderr) or
+            ("sudo: unrecognized option `--derps'" in out.module_stdout) or
             ("sudo: unrecognized option '--derps'" in out.module_stderr)
         fail_msg: out={{out}}

--- a/tests/ansible/integration/become/sudo_nonexistent.yml
+++ b/tests/ansible/integration/become/sudo_nonexistent.yml
@@ -18,5 +18,6 @@
           # removed user/group error messages, as defence against CVE-2019-14287.
           - >-
             ('sudo: unknown user: slartibartfast' in out.module_stderr | default(out.msg))
+            or ('chown: slartibartfast illegal user name' in out.module_stderr | default(out.msg)) # should this avoid using setfacl somehow instead?
             or (ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_version == '6.10')
         fail_msg: out={{out}}


### PR DESCRIPTION
@upekkha did the hard part in https://github.com/mitogen-hq/mitogen/pull/841 (but I don't have permission to amend that PR and want to iterate on CI)

Current issues in CI:

https://app.travis-ci.com/github/mitogen-hq/mitogen/jobs/543521697#L7138 (@moreati is this something you can fix?):
```
+aws ecr-public get-login-password
You must specify a region. You can also configure your region by running "aws configure".
```

https://dev.azure.com/mitogen-hq/mitogen/_build/results?buildId=132&view=logs&j=23e82cb1-eecb-5c20-63ca-90ff600fc34d&t=add3d1fb-cc7d-5aa9-8d1d-a5199d5c5ae7&l=6707 :
```
<localhost> ESTABLISH SSH CONNECTION FOR USER: runner
<localhost> SSH: EXEC ssh -o UserKnownHostsFile=/dev/null -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o 'User="runner"' -o ConnectTimeout=10 -o ControlPath=/Users/runner/.ansible/cp/5b16a1565c localhost '/bin/sh -c '"'"'setfacl -m u:slartibartfast:r-x /var/tmp/ansible-tmp-1634351113.25-27064-235129016913435/ /var/tmp/ansible-tmp-1634351113.25-27064-235129016913435/AnsiballZ_command.py && sleep 0'"'"''
<localhost> (127, '', '/bin/sh: setfacl: command not found\n')
<localhost> Failed to connect to the host via ssh: /bin/sh: setfacl: command not found
<localhost> ESTABLISH SSH CONNECTION FOR USER: runner
<localhost> SSH: EXEC ssh -o UserKnownHostsFile=/dev/null -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o 'User="runner"' -o ConnectTimeout=10 -o ControlPath=/Users/runner/.ansible/cp/5b16a1565c localhost '/bin/sh -c '"'"'chmod u+x /var/tmp/ansible-tmp-1634351113.25-27064-235129016913435/ /var/tmp/ansible-tmp-1634351113.25-27064-235129016913435/AnsiballZ_command.py && sleep 0'"'"''
<localhost> (0, '', '')
<localhost> ESTABLISH SSH CONNECTION FOR USER: runner
<localhost> SSH: EXEC ssh -o UserKnownHostsFile=/dev/null -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o 'User="runner"' -o ConnectTimeout=10 -o ControlPath=/Users/runner/.ansible/cp/5b16a1565c localhost '/bin/sh -c '"'"'chown slartibartfast /var/tmp/ansible-tmp-1634351113.25-27064-235129016913435/ /var/tmp/ansible-tmp-1634351113.25-27064-235129016913435/AnsiballZ_command.py && sleep 0'"'"''
<localhost> (1, '', 'chown: slartibartfast: illegal user name\n')
<localhost> Failed to connect to the host via ssh: chown: slartibartfast: illegal user name
fatal: /Users/runner/work/1/s/tests/ansible/integration/become/sudo_nonexistent.yml:6: [target]: FAILED! => {
  msg: Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user (rc: 1, err: chown: slartibartfast: illegal user name
  msg: }). For information on working around this, see https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user
}
```