### PR TITLE
mitogen.parent: Eliminate use of platform module in first stage

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,7 @@ v0.3.1.dev0 (unreleased)
 * :gh:issue:`869` Continuous Integration tests are now run with Tox
 * :gh:issue:`869` Continuous Integration tests now cover CentOS 6 & 8, Debian 9 & 11, Ubuntu 16.04 & 20.04
 * :gh:issue:`860` Add initial support for podman connection (w/o Ansible support yet)
+* :gh:issue:`873` `python -c ...` first stage no longer uses :py:mod:`platform`` to detect the macOS release
 
 
 v0.3.0 (2021-11-24)


### PR DESCRIPTION
This reduces the size of the initial SSH command by 204 bytes, & may fix errors
running Mitogen on  macOS. AFAICT platform was used but not imported.

Before
```
$ python ./preamble_size.py
SSH command size: 833
Bootstrap (mitogen.core) size: 17007 (16.61KiB)

                              Original          Minimized           Compressed
mitogen.parent            97565 95.3KiB  50427 49.2KiB 51.7%  12689 12.4KiB 13.0%
mitogen.fork               8436  8.2KiB   4130  4.0KiB 49.0%   1648  1.6KiB 19.5%
mitogen.ssh               10892 10.6KiB   6952  6.8KiB 63.8%   2113  2.1KiB 19.4%
mitogen.sudo              12089 11.8KiB   5924  5.8KiB 49.0%   2249  2.2KiB 18.6%
mitogen.select            12325 12.0KiB   2929  2.9KiB 23.8%    964  0.9KiB 7.8%
mitogen.service           41644 40.7KiB  22431 21.9KiB 53.9%   5886  5.7KiB 14.1%
mitogen.fakessh           15599 15.2KiB   8011  7.8KiB 51.4%   2624  2.6KiB 16.8%
mitogen.master            48732 47.6KiB  24569 24.0KiB 50.4%   6768  6.6KiB 13.9%
```

After
```
$ python preamble_size.py
SSH command size: 629
Bootstrap (mitogen.core) size: 17007 (16.61KiB)

                              Original          Minimized           Compressed
mitogen.parent            97543 95.3KiB  50357 49.2KiB 51.6%  12665 12.4KiB 13.0%
mitogen.fork               8436  8.2KiB   4130  4.0KiB 49.0%   1648  1.6KiB 19.5%
mitogen.ssh               10892 10.6KiB   6952  6.8KiB 63.8%   2113  2.1KiB 19.4%
mitogen.sudo              12089 11.8KiB   5924  5.8KiB 49.0%   2249  2.2KiB 18.6%
mitogen.select            12325 12.0KiB   2929  2.9KiB 23.8%    964  0.9KiB 7.8%
mitogen.service           41644 40.7KiB  22431 21.9KiB 53.9%   5886  5.7KiB 14.1%
mitogen.fakessh           15599 15.2KiB   8011  7.8KiB 51.4%   2624  2.6KiB 16.8%
mitogen.master            48732 47.6KiB  24569 24.0KiB 50.4%   6768  6.6KiB 13.9%
```