### PR TITLE
ci: One Tox environment per Azure job

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -20,19 +20,35 @@ jobs:
     vmImage: macOS-10.15
   strategy:
     matrix:
-      Mito27_27:
+      Mito_27:
         python.version: '2.7'
         tox.env: py27-mode_mitogen
 
       # TODO: test python3, python3 tests are broken
-      Local_Py27:
+      Loc_27_210:
         python.version: '2.7'
-        tox.env: py27-mode_localhost-ansible{2.10,3,4}
+        tox.env: py27-mode_localhost-ansible2.10
+      Loc_27_3:
+        python.version: '2.7'
+        tox.env: py27-mode_localhost-ansible3
+      Loc_27_4:
+        python.version: '2.7'
+        tox.env: py27-mode_localhost-ansible4
 
       # NOTE: this hangs when ran in Ubuntu 18.04
-      Vanilla_Py27:
+      Van_27_210:
         python.version: '2.7'
-        tox.env: py27-mode_localhost-ansible{2.10,3,4}
+        tox.env: py27-mode_localhost-ansible2.10
+        STRATEGY: linear
+        ANSIBLE_SKIP_TAGS: resource_intensive
+      Van_27_3:
+        python.version: '2.7'
+        tox.env: py27-mode_localhost-ansible3
+        STRATEGY: linear
+        ANSIBLE_SKIP_TAGS: resource_intensive
+      Van_27_4:
+        python.version: '2.7'
+        tox.env: py27-mode_localhost-ansible4
         STRATEGY: linear
         ANSIBLE_SKIP_TAGS: resource_intensive
 
@@ -45,17 +61,89 @@ jobs:
   - template: azure-pipelines-steps.yml
   strategy:
     matrix:
-      Mito_Py27:
+      Mito_27_centos6:
         python.version: '2.7'
-        tox.env: py27-mode_mitogen-distro_{centos6,centos7,centos8,debian9,debian10,debian11,ubuntu1604,ubuntu1804,ubuntu2004}
+        tox.env: py27-mode_mitogen-distro_centos6
+      Mito_27_centos7:
+        python.version: '2.7'
+        tox.env: py27-mode_mitogen-distro_centos7
+      Mito_27_centos8:
+        python.version: '2.7'
+        tox.env: py27-mode_mitogen-distro_centos8
+      Mito_27_debian9:
+        python.version: '2.7'
+        tox.env: py27-mode_mitogen-distro_debian9
+      Mito_27_debian10:
+        python.version: '2.7'
+        tox.env: py27-mode_mitogen-distro_debian10
+      Mito_27_debian11:
+        python.version: '2.7'
+        tox.env: py27-mode_mitogen-distro_debian11
+      Mito_27_ubuntu1604:
+        python.version: '2.7'
+        tox.env: py27-mode_mitogen-distro_ubuntu1604
+      Mito_27_ubuntu1804:
+        python.version: '2.7'
+        tox.env: py27-mode_mitogen-distro_ubuntu1804
+      Mito_27_ubuntu2004:
+        python.version: '2.7'
+        tox.env: py27-mode_mitogen-distro_ubuntu2004
 
-      Mito_Py36:
+      Mito_36_centos6:
         python.version: '3.6'
-        tox.env: py36-mode_mitogen-distro_{centos6,centos7,centos8,debian9,debian10,debian11,ubuntu1604,ubuntu1804,ubuntu2004}
+        tox.env: py36-mode_mitogen-distro_centos6
+      Mito_36_centos7:
+        python.version: '3.6'
+        tox.env: py36-mode_mitogen-distro_centos7
+      Mito_36_centos8:
+        python.version: '3.6'
+        tox.env: py36-mode_mitogen-distro_centos8
+      Mito_36_debian9:
+        python.version: '3.6'
+        tox.env: py36-mode_mitogen-distro_debian9
+      Mito_36_debian10:
+        python.version: '3.6'
+        tox.env: py36-mode_mitogen-distro_debian10
+      Mito_36_debian11:
+        python.version: '3.6'
+        tox.env: py36-mode_mitogen-distro_debian11
+      Mito_36_ubuntu1604:
+        python.version: '3.6'
+        tox.env: py36-mode_mitogen-distro_ubuntu1604
+      Mito_36_ubuntu1804:
+        python.version: '3.6'
+        tox.env: py36-mode_mitogen-distro_ubuntu1804
+      Mito_36_ubuntu2004:
+        python.version: '3.6'
+        tox.env: py36-mode_mitogen-distro_ubuntu2004
 
-      Mito_Py39:
+      Mito_39_centos6:
         python.version: '3.9'
-        tox.env: py39-mode_mitogen-distro_{centos6,centos7,centos8,debian9,debian10,debian11,ubuntu1604,ubuntu1804,ubuntu2004}
+        tox.env: py39-mode_mitogen-distro_centos6
+      Mito_39_centos7:
+        python.version: '3.9'
+        tox.env: py39-mode_mitogen-distro_centos7
+      Mito_39_centos8:
+        python.version: '3.9'
+        tox.env: py39-mode_mitogen-distro_centos8
+      Mito_39_debian9:
+        python.version: '3.9'
+        tox.env: py39-mode_mitogen-distro_debian9
+      Mito_39_debian10:
+        python.version: '3.9'
+        tox.env: py39-mode_mitogen-distro_debian10
+      Mito_39_debian11:
+        python.version: '3.9'
+        tox.env: py39-mode_mitogen-distro_debian11
+      Mito_39_ubuntu1604:
+        python.version: '3.9'
+        tox.env: py39-mode_mitogen-distro_ubuntu1604
+      Mito_39_ubuntu1804:
+        python.version: '3.9'
+        tox.env: py39-mode_mitogen-distro_ubuntu1804
+      Mito_39_ubuntu2004:
+        python.version: '3.9'
+        tox.env: py39-mode_mitogen-distro_ubuntu2004
 
       #DebOps_2460_27_27:
         #python.version: '2.7'
@@ -94,14 +182,32 @@ jobs:
         #DISTROS: debian
         #STRATEGY: linear
 
-      Ansible_Py27:
+      Ans_27_210:
         python.version: '2.7'
-        tox.env: py27-mode_ansible-ansible{2.10,3,4}
+        tox.env: py27-mode_ansible-ansible2.10
+      Ans_27_3:
+        python.version: '2.7'
+        tox.env: py27-mode_ansible-ansible3
+      Ans_27_4:
+        python.version: '2.7'
+        tox.env: py27-mode_ansible-ansible4
 
-      Ansible_Py36:
+      Ans_36_210:
         python.version: '3.6'
-        tox.env: py36-mode_ansible-ansible{2.10,3,4}
+        tox.env: py36-mode_ansible-ansible2.10
+      Ans_36_3:
+        python.version: '3.6'
+        tox.env: py36-mode_ansible-ansible3
+      Ans_36_4:
+        python.version: '3.6'
+        tox.env: py36-mode_ansible-ansible4
 
-      Ansible_Py39:
+      Ans_39_210:
         python.version: '3.9'
-        tox.env: py39-mode_ansible-ansible{2.10,3,4}
+        tox.env: py39-mode_ansible-ansible2.10
+      Ans_39_3:
+        python.version: '3.9'
+        tox.env: py39-mode_ansible-ansible3
+      Ans_39_4:
+        python.version: '3.9'
+        tox.env: py39-mode_ansible-ansible4


### PR DESCRIPTION
Should result in
- better isolation of faults
- easier retries of failed jobs
- quicker test completion, to to more efficient queueing.

This does not expand test coverage, merely rearranges the tests already run.