### PR TITLE
mitogen.parent: Remove tabs from minimized first stage

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,7 @@ v0.3.1.dev0 (unreleased)
 * :gh:issue:`869` Continuous Integration tests now cover CentOS 6 & 8, Debian 9 & 11, Ubuntu 16.04 & 20.04
 * :gh:issue:`860` Add initial support for podman connection (w/o Ansible support yet)
 * :gh:issue:`873` `python -c ...` first stage no longer uses :py:mod:`platform`` to detect the macOS release
+* :gh:issue:`876` `python -c ...` first stage no longer contains tab characters, to reduce size
 
 
 v0.3.0 (2021-11-24)

--- a/mitogen/parent.py
+++ b/mitogen/parent.py
@@ -1467,7 +1467,7 @@ class Connection(object):
     def get_boot_command(self):
         source = inspect.getsource(self._first_stage)
         source = textwrap.dedent('\n'.join(source.strip().split('\n')[2:]))
-        source = source.replace('    ', '\t')
+        source = source.replace('    ', ' ')
         source = source.replace('CONTEXT_NAME', self.options.remote_name)
         preamble_compressed = self.get_preamble()
         source = source.replace('PREAMBLE_COMPRESSED_LEN',

--- a/preamble_size.py
+++ b/preamble_size.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
 Print the size of a typical SSH command line and the bootstrap code sent to new
 contexts.


### PR DESCRIPTION
Saves 4 bytes

Before
```
$ python preamble_size.py
SSH command size: 629
Bootstrap (mitogen.core) size: 17007 (16.61KiB)

                              Original          Minimized           Compressed
mitogen.parent            97497 95.2KiB  50356 49.2KiB 51.6%  12665 12.4KiB 13.0%
mitogen.fork               8436  8.2KiB   4130  4.0KiB 49.0%   1648  1.6KiB 19.5%
mitogen.ssh               10892 10.6KiB   6952  6.8KiB 63.8%   2113  2.1KiB 19.4%
mitogen.sudo              12089 11.8KiB   5924  5.8KiB 49.0%   2249  2.2KiB 18.6%
mitogen.select            12325 12.0KiB   2929  2.9KiB 23.8%    964  0.9KiB 7.8%
mitogen.service           41644 40.7KiB  22431 21.9KiB 53.9%   5886  5.7KiB 14.1%
mitogen.fakessh           15599 15.2KiB   8011  7.8KiB 51.4%   2624  2.6KiB 16.8%
mitogen.master            48732 47.6KiB  24569 24.0KiB 50.4%   6768  6.6KiB 13.9%
```

After
```
$ python preamble_size.py
SSH command size: 625
Bootstrap (mitogen.core) size: 17007 (16.61KiB)

                              Original          Minimized           Compressed
mitogen.parent            97496 95.2KiB  50355 49.2KiB 51.6%  12663 12.4KiB 13.0%
mitogen.fork               8436  8.2KiB   4130  4.0KiB 49.0%   1648  1.6KiB 19.5%
mitogen.ssh               10892 10.6KiB   6952  6.8KiB 63.8%   2113  2.1KiB 19.4%
mitogen.sudo              12089 11.8KiB   5924  5.8KiB 49.0%   2249  2.2KiB 18.6%
mitogen.select            12325 12.0KiB   2929  2.9KiB 23.8%    964  0.9KiB 7.8%
mitogen.service           41644 40.7KiB  22431 21.9KiB 53.9%   5886  5.7KiB 14.1%
mitogen.fakessh           15599 15.2KiB   8011  7.8KiB 51.4%   2624  2.6KiB 16.8%
mitogen.master            48732 47.6KiB  24569 24.0KiB 50.4%   6768  6.6KiB 13.9%
```