### PR TITLE
ensure ssh_args is passed as a list

### DIFF
--- a/mitogen/ssh.py
+++ b/mitogen/ssh.py
@@ -213,6 +213,8 @@ class Options(mitogen.parent.Options):
         if ssh_path:
             self.ssh_path = ssh_path
         if ssh_args:
+            if not isinstance(ssh_args, list):
+                raise ValueError('ssh_args expected to be a list')
             self.ssh_args = ssh_args
         if ssh_debug_level:
             self.ssh_debug_level = ssh_debug_level


### PR DESCRIPTION
Passing `ssh_args` as a string creates an implicit (and confusing) error:
```
mitogen.parent.EofError: EOF on stream; last 100 lines received:
ssh: Could not resolve hostname -: Name or service not known
```
Instead, ensure that the type is as expected.