### PR TITLE
Handle distro 1.7.0's switch from module to package

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,7 @@ v0.3.1.dev0 (unreleased)
 * :gh:issue:`876` `python -c ...` first stage no longer contains tab characters, to reduce size
 * :gh:issue:`878` Continuous Integration tests now correctly perform comparisons of 2 digit versions
 * :gh:issue:`878` Kubectl connector fixed with Ansible 2.10 and above
+* :gh:issue:`906` Support the presence of distro >= 1.7.0.
 
 
 v0.3.0 (2021-11-24)

--- a/mitogen/master.py
+++ b/mitogen/master.py
@@ -654,7 +654,7 @@ class ParentEnumerationMethod(FinderMethod):
 
             pkg = sys.modules.get(pkgname)
             path = getattr(pkg, '__path__', None)
-            if pkg and path:
+            if pkg and path and pkgname != 'ansible.module_utils.distro':
                 return pkgname.split('.'), path, modpath
 
             LOG.debug('%r: %r lacks __path__ attribute', self, pkgname)


### PR DESCRIPTION
`ansible.module_utils.distro` replaces itself with either the `distro` module, when it exists, or the bundled distro module.

If a target doesn't have a system `distro` module, it will try to load the bundled distro module (`ansible.module_utils.distro._distro`). This is tricky, because `sys.modules['ansible.module_utils.distro']` points to the
distro package. `ParentEnumerationMethod()` walks up the module tree, to get above this misdirection.

The change from a module to package in distro 1.7.0 broke `ParentEnumerationMethod`'s heuristics. Hardcode avoiding the module `'ansible.module_utils.distro'` as an import starting point.

Fixes: #906