### PR TITLE
master.ParentEnumerationMethod: Require matching pkg.__name__

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,10 @@ To avail of fixes in an unreleased version, please download a ZIP file
 `directly from GitHub <https://github.com/dw/mitogen/>`_.
 
 
+v0.3.3.dev0
+-------------------
+
+
 v0.3.2 (2022-01-12)
 -------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,8 +18,14 @@ To avail of fixes in an unreleased version, please download a ZIP file
 `directly from GitHub <https://github.com/dw/mitogen/>`_.
 
 
-v0.3.1.dev0 (unreleased)
-------------------------
+v0.3.2 (2022-01-12)
+-------------------
+
+* :gh:issue:`891` Correct `Framework :: Ansible` Trove classifier
+
+
+v0.3.1 (unreleased)
+-------------------
 
 * :gh:issue:`874` Support for Ansible 5 (ansible-core 2.12)
 * :gh:issue:`774` Fix bootstrap failures on macOS 11.x and 12.x, involving Python 2.7 wrapper

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,8 @@ To avail of fixes in an unreleased version, please download a ZIP file
 v0.3.3.dev0
 -------------------
 
+* :gh:issue:`906` Support packages dynamically inserted into sys.modules, e.g. `distro` >= 1.7.0 as `ansible.module_utils.distro`.
+
 
 v0.3.2 (2022-01-12)
 -------------------

--- a/mitogen/__init__.py
+++ b/mitogen/__init__.py
@@ -35,7 +35,7 @@ be expected. On the slave, it is built dynamically during startup.
 
 
 #: Library version as a tuple.
-__version__ = (0, 3, 1, 'dev0')
+__version__ = (0, 3, 2)
 
 
 #: This is :data:`False` in slave contexts. Previously it was used to prevent

--- a/mitogen/__init__.py
+++ b/mitogen/__init__.py
@@ -35,7 +35,7 @@ be expected. On the slave, it is built dynamically during startup.
 
 
 #: Library version as a tuple.
-__version__ = (0, 3, 2)
+__version__ = (0, 3, 3, 'dev0')
 
 
 #: This is :data:`False` in slave contexts. Previously it was used to prevent

--- a/mitogen/core.py
+++ b/mitogen/core.py
@@ -1357,6 +1357,16 @@ class Importer(object):
             fp.close()
 
     def find_module(self, fullname, path=None):
+        """
+        Return a loader (ourself) or None, for the module with fullname.
+
+        Implements importlib.abc.MetaPathFinder.find_module().
+        Deprecrated in Python 3.4+, replaced by find_spec().
+        Raises ImportWarning in Python 3.10+.
+
+        fullname    A (fully qualified?) module name, e.g. "os.path".
+        path        __path__ of parent packge. None for a top level module.
+        """
         if hasattr(_tls, 'running'):
             return None
 
@@ -1478,6 +1488,12 @@ class Importer(object):
             callback()
 
     def load_module(self, fullname):
+        """
+        Return the loaded module specified by fullname.
+
+        Implements importlib.abc.Loader.load_module().
+        Deprecated in Python 3.4+, replaced by create_module() & exec_module().
+        """
         fullname = to_text(fullname)
         _v and self._log.debug('requesting %s', fullname)
         self._refuse_imports(fullname)

--- a/mitogen/master.py
+++ b/mitogen/master.py
@@ -122,6 +122,13 @@ def is_stdlib_name(modname):
     """
     Return :data:`True` if `modname` appears to come from the standard library.
     """
+    # `imp.is_builtin()` isn't a documented as part of Python's stdlib API.
+    #
+    # """
+    # Main is a little special - imp.is_builtin("__main__") will return False,
+    # but BuiltinImporter is still the most appropriate initial setting for
+    # its __loader__ attribute.
+    # """ -- comment in CPython pylifecycle.c:add_main_module()
     if imp.is_builtin(modname) != 0:
         return True
 
@@ -512,6 +519,8 @@ class PkgutilMethod(FinderMethod):
         Find `fullname` using :func:`pkgutil.find_loader`.
         """
         try:
+            # If fullname refers to a submodule that's not already imported
+            # then the containing package is imported.
             # Pre-'import spec' this returned None, in Python3.6 it raises
             # ImportError.
             loader = pkgutil.find_loader(fullname)

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     zip_safe = False,
     classifiers = [
         'Environment :: Console',
-        'Frameworks :: Ansible',
+        'Framework :: Ansible',
         'Intended Audience :: System Administrators',
         'License :: OSI Approved :: BSD License',
         'Operating System :: MacOS :: MacOS X',


### PR DESCRIPTION
Co-authored-by: Stefano Rivera <stefano@rivera.za.net>

When the requested module (e.g. `ansible.module_utils.distro`)
- is provided by another module (e.g. `distro`)
- that itself was a package (e.g. distro 1.7.0)

At runtime
- `ansible/module_utils/distro/__init__.py` executes
- if https://pypi.org/project/distro/ is present, it's loaded as `ansible.module_utils.distro`
- otherwise `ansible/module_utils/distro/_distro.py` is loaded

ParentEnumerationMethod would wrongly use whatever was in `sys.modules['ansible.module_utils.distro]`. Instead we should ascend to the first parent that has `fullname == sys.modules[fullname].__name__`. Then descend to the appropriate .py file on disk.

This bug didn't show up before because until distro 1.7.0 (Feb 2022) the top-level distro module was a module (`distro.py`) not a package (`distro/__init__.py`)

fixes #906