### PR TITLE
Fix [DEPRECATION WARNING]: The '_remote_checksum()' method is deprecated.

### DIFF
--- a/ansible_mitogen/plugins/action/mitogen_fetch.py
+++ b/ansible_mitogen/plugins/action/mitogen_fetch.py
@@ -70,8 +70,8 @@ class ActionModule(ActionBase):
 
             remote_stat = {}
             remote_checksum = None
-            if not self._connection.become:
-                # Get checksum for the remote file. Don't bother if using become as slurp will be used.
+            if True:
+                # Get checksum for the remote file even using become. Mitogen doesn't need slurp.
                 # Follow symlinks because fetch always follows symlinks
                 try:
                     remote_stat = self._execute_remote_stat(source, all_vars=task_vars, follow=True)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,7 @@ v0.3.3.dev0
 * :gh:issue:`918` Support Python 3.10
 * :gh:issue:`920` Support Ansible :ans:conn:`~podman` connection plugin
 * :gh:issue:`836` :func:`mitogen.utils.with_router` decorator preserves the docstring in addition to the name.
+* :gh:issue:`936` :ans:mod:`fetch` no longer emits `[DEPRECATION WARNING]: The '_remote_checksum()' method is deprecated.`
 
 
 v0.3.2 (2022-01-12)

--- a/tests/ansible/regression/issue_615__streaming_transfer.yml
+++ b/tests/ansible/regression/issue_615__streaming_transfer.yml
@@ -1,23 +1,32 @@
 # issue #615: 'fetch' with become: was internally using slurp.
 
-- hosts: target
+- hosts: test-targets
   any_errors_fatal: True
   gather_facts: no
+  # Without Mitogen this causes Ansible to use the slurp module, which is *slow*
   become: true
   vars:
     mitogen_ssh_compression: false
   tasks:
-    - shell: |
-        dd if=/dev/zero of=/tmp/512mb.zero bs=1048576 count=512;
-        chmod go= /tmp/512mb.zero
+    - block:
+        - shell: |
+            dd if=/dev/zero of=/tmp/512mb.zero bs=1048576 count=512;
+            chmod go= /tmp/512mb.zero
 
-    - fetch:
-        src: /tmp/512mb.zero
-        dest: /tmp/fetch-out
+        - fetch:
+            src: /tmp/512mb.zero
+            dest: /tmp/fetch-out
 
-    - file:
-        path: /tmp/fetch-out
-        state: absent
-      delegate_to: localhost
+        - file:
+            path: /tmp/512mb.zero
+            state: absent
+
+        - file:
+            path: /tmp/fetch-out
+            state: absent
+          delegate_to: localhost
+          run_once: true
+      when:
+        - is_mitogen
   tags:
     - issue_615


### PR DESCRIPTION
This reapplies an earlier change, when this plugin was first introduced to Mitogen. The plugin was updated to fix

> [DEPRECATION WARNING]: The '_remote_checksum()' method is deprecated.

I've elected to short-circuit the if statemtn logic, rather than
deleting/unindenting, to make the code delta much smaller. This should make it
easier to maintain/update.

Fixes https://github.com/mitogen-hq/mitogen/issues/915