### PR TITLE
tests/ansible/README: Replace reference with actual link

### DIFF
--- a/tests/ansible/README.md
+++ b/tests/ansible/README.md
@@ -10,7 +10,7 @@ demonstrator for what does and doesn't work.
 
 ## Preparation
 
-See `../image_prep/README.md`.
+See [`../image_prep/README.md`](../image_prep/README.md).
 
 
 ## `run_ansible_playbook.py`


### PR DESCRIPTION
- working for GitHub and similar Markdown engines
- I think no other documentations need to be updated and also no changelog entry is required for such small change in a README
