### PR TITLE
Fix runtime error when using the ansible.builtin.dnf module multiple times

### DIFF
--- a/ansible_mitogen/planner.py
+++ b/ansible_mitogen/planner.py
@@ -323,6 +323,7 @@ class NewStylePlanner(ScriptPlanner):
         'dnf',  # issue #280; py-dnf/hawkey need therapy
         'firewalld',  # issue #570: ansible module_utils caches dbus conn
         'ansible.legacy.dnf',  # issue #776
+        'ansible.builtin.dnf', # issue #832
     ])
 
     def should_fork(self):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,7 @@ To avail of fixes in an unreleased version, please download a ZIP file
 v0.3.4.dev0
 -------------------
 
+* :gh:issue:`832` Fix runtime error when using the ansible.builtin.dnf module multiple times
 
 v0.3.3 (2022-06-03)
 -------------------


### PR DESCRIPTION
The fully qualified name of the `dnf` module needs to also be added to the `ALWAYS_FORK_MODULES` list.

Fixes #832

