### PR TITLE
simplejson py2 only syntax fix

### DIFF
--- a/ansible_mitogen/compat/simplejson/decoder.py
+++ b/ansible_mitogen/compat/simplejson/decoder.py
@@ -145,7 +145,8 @@ scanstring = c_scanstring or py_scanstring
 WHITESPACE = re.compile(r'[ \t\n\r]*', FLAGS)
 WHITESPACE_STR = ' \t\n\r'
 
-def JSONObject((s, end), encoding, strict, scan_once, object_hook, _w=WHITESPACE.match, _ws=WHITESPACE_STR):
+def JSONObject(state, encoding, strict, scan_once, object_hook, _w=WHITESPACE.match, _ws=WHITESPACE_STR):
+    (s, end) = state
     pairs = {}
     # Use a slice to prevent IndexError from being raised, the following
     # check will raise a more specific ValueError if the string is empty
@@ -220,7 +221,8 @@ def JSONObject((s, end), encoding, strict, scan_once, object_hook, _w=WHITESPACE
         pairs = object_hook(pairs)
     return pairs, end
 
-def JSONArray((s, end), scan_once, _w=WHITESPACE.match, _ws=WHITESPACE_STR):
+def JSONArray(state, scan_once, _w=WHITESPACE.match, _ws=WHITESPACE_STR):
+    (s, end) = state
     values = []
     nextchar = s[end:end + 1]
     if nextchar in _ws:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,7 @@ To avail of fixes in an unreleased version, please download a ZIP file
 v0.3.4.dev0
 -------------------
 
+* :gh:issue:`659` Simplejson python2 only syntax generates errors with python3
 * :gh:issue:`929` Support Ansible 6 and ansible-core 2.13
 * :gh:issue:`832` Fix runtime error when using the ansible.builtin.dnf module multiple times
 


### PR DESCRIPTION
This patch fixes the python 2 only syntax from some simplejson method definitions. The patch is directly inspired from [what simplejson does today](https://github.com/simplejson/simplejson/blob/43645252224d4e529c22cb78ac42f241d6426073/simplejson/decoder.py#L144).

This fixes #659 