### PR TITLE
add SSH args into options documentation

### DIFF
--- a/ansible_mitogen/plugins/connection/mitogen_ssh.py
+++ b/ansible_mitogen/plugins/connection/mitogen_ssh.py
@@ -42,6 +42,24 @@ DOCUMENTATION = """
           accepts.
     version_added: "2.5"
     options:
+        ssh_args:
+            type: str
+            vars:
+                - name: ssh_args
+                - name: ansible_ssh_args
+                - name: ansible_mitogen_ssh_args
+        ssh_common_args:
+            type: str
+            vars:
+                - name: ssh_args
+                - name: ansible_ssh_common_args
+                - name: ansible_mitogen_ssh_common_args
+        ssh_extra_args:
+            type: str
+            vars:
+                - name: ssh_args
+                - name: ansible_ssh_extra_args
+                - name: ansible_mitogen_ssh_extra_args
 """
 
 try:


### PR DESCRIPTION
During ansible update from **2.9** to **2.12** I faced issues with `synchronize` action:
```
KeyError: 'Requested entry (plugin_type: connection plugin: mitogen_ssh setting: ssh_args ) was not defined in configuration.'
```

Tracing down the error I discovered:

`ansible.posix` since 1.3.0 uses underlying SSH connection to determine SSH options:
```python
ssh_args = [
    self._connection.get_option('ssh_args'),
    self._connection.get_option('ssh_common_args'),
    self._connection.get_option('ssh_extra_args'),
]
```
https://github.com/ansible-collections/ansible.posix/blob/1.4.0/plugins/action/synchronize.py#L183

`AnsiblePlugin` uses ConfigManager to retrieve a value for an option:
```python
def get_option(self, option, hostvars=None):
    ...
    option_value = C.config.get_config_value(option, plugin_type=get_plugin_class(self), plugin_name=self._load_name, variables=hostvars)
    ...
```
https://github.com/ansible/ansible/blob/v2.12.7/lib/ansible/plugins/__init__.py#L55

`ConfigManager` uses configuration definitions for option's lookup:
```python
def get_config_value_and_origin(self, config, cfile=None, plugin_type=None, plugin_name=None, keys=None, variables=None, direct=None):
    ...
    defs = self.get_configuration_definitions(plugin_type, plugin_name)
    if config in defs:
        ...
    else:
        raise AnsibleError('Requested entry (%s) was not defined in configuration.' % to_native(_get_entry(plugin_type, plugin_name, config)))
```
https://github.com/ansible/ansible/blob/v2.12.7/lib/ansible/config/manager.py#L433

And `PluginLoader` sets definitons uses DOCUMENTATION constant:
```python
def _load_config_defs(self, name, module, path):
    ...
    dstring = AnsibleLoader(getattr(module, 'DOCUMENTATION', ''), file_name=path).get_single_data()
        ...
        if dstring and 'options' in dstring and isinstance(dstring['options'], dict):
            C.config.initialize_plugin_configuration_definitions(type_name, name, dstring['options'])
```
https://github.com/ansible/ansible/blob/v2.12.7/lib/ansible/plugins/loader.py#L409