### PR TITLE
ansible_mitogen: correct typo in MitogenViaSpec.mitogen_lxc_path()

### DIFF
--- a/ansible_mitogen/transport_config.py
+++ b/ansible_mitogen/transport_config.py
@@ -753,7 +753,7 @@ class MitogenViaSpec(Spec):
         return self._host_vars.get('mitogen_kubectl_path')
 
     def mitogen_lxc_path(self):
-        return self.host_vars.get('mitogen_lxc_path')
+        return self._host_vars.get('mitogen_lxc_path')
 
     def mitogen_lxc_attach_path(self):
         return self._host_vars.get('mitogen_lxc_attach_path')


### PR DESCRIPTION
self.host_vars -> self._host_vars


> Thanks for creating a PR! Here's a quick checklist to pay attention to:
>
> * Please add an entry to docs/changelog.rst as appropriate.

Do I need to? It's a typo fix to unbreak something.