### PR TITLE
process/Broker: do not reset poller_class. Fixes #967

### DIFF
--- a/ansible_mitogen/process.py
+++ b/ansible_mitogen/process.py
@@ -280,12 +280,7 @@ def get_cpu_count(default=None):
 
 
 class Broker(mitogen.master.Broker):
-    """
-    WorkerProcess maintains at most 2 file descriptors, therefore does not need
-    the exuberant syscall expense of EpollPoller, so override it and restore
-    the poll() poller.
-    """
-    poller_class = mitogen.core.Poller
+    pass
 
 
 class Binding(object):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,7 @@ v0.3.4.dev0
   resource leaks.
 * :gh:issue:`659` Removed :mod:`mitogen.compat.simplejson`, not needed with Python 2.7+, contained Python 3.x syntax errors
 * :gh:issue:`983` CI: Removed PyPI faulthandler requirement from tests
+* :gh:issue:`967` Broker: Do not reset poller_class to mitogen.core.Poller to avoid 'filedescriptor out of range in select()'
 
 v0.3.3 (2022-06-03)
 -------------------


### PR DESCRIPTION
With ansible 2.12.8 and up the brokers may crash on large playbooks and/or many hosts due to the use of `select.select()` which is limited to 1024 file descriptors.
This PR removes resetting the `poller_class` to `mitogen.core.Poller` so the best poller is used instead (that should be at least `select.poll()` which is not limited to 1024 fds).