### PR TITLE
adding support for google auth on mitogen

### DIFF
--- a/mitogen/mitogen-otp-token-via-ansible_password.patch
+++ b/mitogen/mitogen-otp-token-via-ansible_password.patch
@@ -1,0 +1,22 @@
+diff --git a/mitogen/ssh.py b/mitogen/ssh.py
+index 656dc72c..95b02329 100644
+--- a/mitogen/ssh.py
++++ b/mitogen/ssh.py
+@@ -66,8 +66,16 @@ hostkey_failed_msg = (
+ )
+ 
+ # sshpass uses 'assword' because it doesn't lowercase the input.
++#
++# When using google-authenticator's PAM plugin for TOTP challenge,
++# the prompt is not asking for password but "verification code"
++# instead. Allowing this in the pattern will enable the user to
++# pass ansible_password containing a token.
++#
++# Phrase is hardcoded in:
++# https://github.com/google/google-authenticator-libpam/src/pam_google_authenticator.c
+ PASSWORD_PROMPT_PATTERN = re.compile(
+-    b('password'),
++    b('(password|verification code)'),
+     re.I
+ )
+ 

--- a/mitogen/ssh.py
+++ b/mitogen/ssh.py
@@ -66,8 +66,16 @@ hostkey_failed_msg = (
 )
 
 # sshpass uses 'assword' because it doesn't lowercase the input.
+#
+# When using google-authenticator's PAM plugin for TOTP challenge,
+# the prompt is not asking for password but "verification code"
+# instead. Allowing this in the pattern will enable the user to
+# pass ansible_password containing a token.
+#
+# Phrase is hardcoded in:
+# https://github.com/google/google-authenticator-libpam/src/pam_google_authenticator.c
 PASSWORD_PROMPT_PATTERN = re.compile(
-    b('password'),
+    b('(password|verification code)'),
     re.I
 )
 


### PR DESCRIPTION
Thanks for creating a PR! Here's a quick checklist to pay attention to:

* Please add an entry to docs/changelog.rst as appropriate.

* Has some new parameter been added or semantics modified somehow? Please
  ensure relevant documentation is updated in docs/ansible.rst and
  docs/api.rst.

* If it's for new functionality, is there at least a basic test in either
  tests/ or tests/ansible/ covering it?

* If it's for a new connection method, please try to stub out the
  implementation as in tests/data/stubs/, so that construction can be tested
  without having a working configuration.

