### PR TITLE
Fix --ask-become-pass

### DIFF
--- a/.ci/ansible_tests.py
+++ b/.ci/ansible_tests.py
@@ -6,6 +6,7 @@ import glob
 import os
 import signal
 import sys
+import textwrap
 
 import ci_lib
 
@@ -74,7 +75,15 @@ with ci_lib.Fold('job_setup'):
             fp.write('\n[%s]\n' % family)
             fp.writelines('%s\n' % name for name in hostnames)
 
-        fp.write('\n[linux:children]\ntest-targets\n')
+        fp.write(textwrap.dedent(
+            '''
+            [linux:children]
+            test-targets
+
+            [linux_containers:children]
+            test-targets
+            '''
+        ))
 
     ci_lib.dump_file(inventory_path)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,7 @@ To avail of fixes in an unreleased version, please download a ZIP file
 Unreleased
 ----------
 
+* :gh:issue:`952` Fix Ansible `--ask-become-pass`, add test coverage
 
 
 v0.3.7 (2024-04-08)

--- a/tests/ansible/hosts/default.hosts
+++ b/tests/ansible/hosts/default.hosts
@@ -10,3 +10,5 @@ target ansible_host=localhost ansible_user="{{ lookup('pipe', 'whoami') }}"
 
 [test-targets]
 target
+
+[linux_containers]

--- a/tests/ansible/integration/interpreter_discovery/complex_args.yml
+++ b/tests/ansible/integration/interpreter_discovery/complex_args.yml
@@ -29,20 +29,18 @@
         special_python: "source /tmp/fake || true && python{{ ansible_facts.python.version.major }}"
 
     - name: run get_url with specially-sourced python
-      get_url:
+      uri:
         # Plain http for wider Ansible & Python version compatibility
-        url: http://httpbin.org/get
-        dest: "/tmp/"
-        mode: 0644
+        url: http://www.gstatic.com/generate_204
+        status_code: [204]
       vars:
         ansible_python_interpreter: "{{ special_python }}"
 
     - name: run get_url with specially-sourced python including jinja
-      get_url:
+      uri:
         # Plain http for wider Ansible & Python version compatibility
-        url: http://httpbin.org/get
-        dest: "/tmp/"
-        mode: 0644
+        url: http://www.gstatic.com/generate_204
+        status_code: [204]
       vars:
         ansible_python_interpreter: >
           {% if "1" == "1" %}

--- a/tests/ansible/integration/transport_config/become_pass.yml
+++ b/tests/ansible/integration/transport_config/become_pass.yml
@@ -143,8 +143,9 @@
       - out.result|length == 2
       - out.result[0].method == "ssh"
       - out.result[1].method == "sudo"
-      # Ansible >= 2.10 builtin become plugins (e.g. sudo, su) give priority
-      # to ansible_become_pass over ansible_become_password.
+      # Ansible <= 2.9.1 prioritises ansible_become_password.
+      # Ansible >= 2.9.2 prioritises ansible_become_pass.
+      # https://github.com/ansible/ansible/commit/480b106d6535978ae6ecab68b40942ca4fa914a0
       - out.result[1].kwargs.password == "bpass"
       fail_msg: out={{out}}
   tags:

--- a/tests/ansible/regression/all.yml
+++ b/tests/ansible/regression/all.yml
@@ -14,3 +14,4 @@
 - import_playbook: issue_615__streaming_transfer.yml
 - import_playbook: issue_655__wait_for_connection_error.yml
 - import_playbook: issue_776__load_plugins_called_twice.yml
+- import_playbook: issue_952__ask_become_pass.yml

--- a/tests/ansible/regression/become_test.yml
+++ b/tests/ansible/regression/become_test.yml
@@ -1,0 +1,9 @@
+- name: regression/become_test.yml
+  hosts: test-targets:&linux_containers
+  become: true
+  become_user: mitogen__pw_required
+  strategy: mitogen_linear
+  tasks:
+    - command: whoami
+      changed_when: false
+      check_mode: false

--- a/tests/ansible/regression/issue_952__ask_become_pass.yml
+++ b/tests/ansible/regression/issue_952__ask_become_pass.yml
@@ -1,0 +1,21 @@
+- name: regression/issue_952__ask_become_pass.yml
+  hosts: test-targets[0]:&linux_containers
+  gather_facts: false
+  tags:
+    - issue_952
+  tasks:
+    - name: Test --ask-become-pass
+      delegate_to: localhost
+      expect:
+        command: >
+          ansible-playbook
+          {% for inv in ansible_inventory_sources %}
+          -i "{{ inv }}"
+          {% endfor %}
+          --ask-become-pass
+          regression/become_test.yml
+        chdir: ../
+        responses:
+          'BECOME password:': pw_required_password
+      changed_when: false
+      check_mode: false

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -12,6 +12,8 @@ Django==3.2.20;     python_version >= '3.6'
 mock==3.0.5;                python_version == '2.7'
 mock==5.1.0;                python_version >= '3.6'
 
+pexpect==4.8
+
 psutil==5.9.8
 
 pytest==4.6.11;             python_version == '2.7'


### PR DESCRIPTION
Previously f1503874de82353cbed8b51408d20fdfa899f8f7 fixed the priority of `ansible_become_pass` over `ansible_become_password`, but broke `--ask-become-pass`.
Fixes #952.