### PR TITLE
mitogen: Clarify blacklisted import error message

### DIFF
--- a/mitogen/core.py
+++ b/mitogen/core.py
@@ -501,6 +501,7 @@ def is_blacklisted_import(importer, fullname):
     any packages have been whitelisted and `fullname` is not part of one.
 
     NB:
+      - The default whitelist is `['']` which matches any module name.
       - If a package is on both lists, then it is treated as blacklisted.
       - If any package is whitelisted, then all non-whitelisted packages are
         treated as blacklisted.
@@ -1416,9 +1417,9 @@ class Importer(object):
             del _tls.running
 
     blacklisted_msg = (
-        '%r is present in the Mitogen importer blacklist, therefore this '
-        'context will not attempt to request it from the master, as the '
-        'request will always be refused.'
+        "%r is blacklisted (on the Mitogen importer blacklist (%r) or not "
+        "on the whitelist (%r)). This context won't try to request it from "
+        "the master, it would be refused."
     )
     pkg_resources_msg = (
         'pkg_resources is prohibited from importing __main__, as it causes '
@@ -1433,7 +1434,10 @@ class Importer(object):
 
     def _refuse_imports(self, fullname):
         if is_blacklisted_import(self, fullname):
-            raise ModuleNotFoundError(self.blacklisted_msg % (fullname,))
+            raise ModuleNotFoundError(
+                self.blacklisted_msg
+                % (fullname, self.blacklist, self.whitelist),
+            )
 
         f = sys._getframe(2)
         requestee = f.f_globals['__name__']

--- a/tests/responder_test.py
+++ b/tests/responder_test.py
@@ -194,21 +194,3 @@ class ForwardTest(testlib.RouterMixin, testlib.TestCase):
         self.assertEqual(2+os_fork, self.router.responder.good_load_module_count)
         self.assertLess(10000, self.router.responder.good_load_module_size)
         self.assertGreater(40000, self.router.responder.good_load_module_size)
-
-
-class BlacklistTest(testlib.TestCase):
-    @unittest.skip('implement me')
-    def test_whitelist_no_blacklist(self):
-        assert 0
-
-    @unittest.skip('implement me')
-    def test_whitelist_has_blacklist(self):
-        assert 0
-
-    @unittest.skip('implement me')
-    def test_blacklist_no_whitelist(self):
-        assert 0
-
-    @unittest.skip('implement me')
-    def test_blacklist_has_whitelist(self):
-        assert 0


### PR DESCRIPTION
Previous phrasing was misleading - it implied a given module was explicitly on the blacklist, even if it was due to a restrictive whitelist and the blacklist was empty.

Arguably the blacklist/whitelist semantics are themselves misleading. A redesign is tempting.

See also #1011, #808