### PR TITLE
Add Python 3.11 support

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -21,9 +21,9 @@ jobs:
     matrix:
       Mito_27:
         tox.env: py27-mode_mitogen
-      Mito_310:
-        python.version: '3.10'
-        tox.env: py310-mode_mitogen
+      Mito_311:
+        python.version: '3.11'
+        tox.env: py311-mode_mitogen
 
       # TODO: test python3, python3 tests are broken
       Loc_27_210:
@@ -96,33 +96,33 @@ jobs:
         python.version: '3.6'
         tox.env: py36-mode_mitogen-distro_ubuntu2004
 
-      Mito_310_centos6:
-        python.version: '3.10'
-        tox.env: py310-mode_mitogen-distro_centos6
-      Mito_310_centos7:
-        python.version: '3.10'
-        tox.env: py310-mode_mitogen-distro_centos7
-      Mito_310_centos8:
-        python.version: '3.10'
-        tox.env: py310-mode_mitogen-distro_centos8
-      Mito_310_debian9:
-        python.version: '3.10'
-        tox.env: py310-mode_mitogen-distro_debian9
-      Mito_310_debian10:
-        python.version: '3.10'
-        tox.env: py310-mode_mitogen-distro_debian10
-      Mito_310_debian11:
-        python.version: '3.10'
-        tox.env: py310-mode_mitogen-distro_debian11
-      Mito_310_ubuntu1604:
-        python.version: '3.10'
-        tox.env: py310-mode_mitogen-distro_ubuntu1604
-      Mito_310_ubuntu1804:
-        python.version: '3.10'
-        tox.env: py310-mode_mitogen-distro_ubuntu1804
-      Mito_310_ubuntu2004:
-        python.version: '3.10'
-        tox.env: py310-mode_mitogen-distro_ubuntu2004
+      Mito_311_centos6:
+        python.version: '3.11'
+        tox.env: py311-mode_mitogen-distro_centos6
+      Mito_311_centos7:
+        python.version: '3.11'
+        tox.env: py311-mode_mitogen-distro_centos7
+      Mito_311_centos8:
+        python.version: '3.11'
+        tox.env: py311-mode_mitogen-distro_centos8
+      Mito_311_debian9:
+        python.version: '3.11'
+        tox.env: py311-mode_mitogen-distro_debian9
+      Mito_311_debian10:
+        python.version: '3.11'
+        tox.env: py311-mode_mitogen-distro_debian10
+      Mito_311_debian11:
+        python.version: '3.11'
+        tox.env: py311-mode_mitogen-distro_debian11
+      Mito_311_ubuntu1604:
+        python.version: '3.11'
+        tox.env: py311-mode_mitogen-distro_ubuntu1604
+      Mito_311_ubuntu1804:
+        python.version: '3.11'
+        tox.env: py311-mode_mitogen-distro_ubuntu1804
+      Mito_311_ubuntu2004:
+        python.version: '3.11'
+        tox.env: py311-mode_mitogen-distro_ubuntu2004
 
       Ans_27_210:
         tox.env: py27-mode_ansible-ansible2.10
@@ -136,18 +136,18 @@ jobs:
         python.version: '3.6'
         tox.env: py36-mode_ansible-ansible4
 
-      Ans_310_210:
-        python.version: '3.10'
-        tox.env: py310-mode_ansible-ansible2.10
-      Ans_310_3:
-        python.version: '3.10'
-        tox.env: py310-mode_ansible-ansible3
-      Ans_310_4:
-        python.version: '3.10'
-        tox.env: py310-mode_ansible-ansible4
-      Ans_310_5:
-        python.version: '3.10'
-        tox.env: py310-mode_ansible-ansible5
-      Ans_310_6:
-        python.version: '3.10'
-        tox.env: py310-mode_ansible-ansible6
+      Ans_311_210:
+        python.version: '3.11'
+        tox.env: py311-mode_ansible-ansible2.10
+      Ans_311_3:
+        python.version: '3.11'
+        tox.env: py311-mode_ansible-ansible3
+      Ans_311_4:
+        python.version: '3.11'
+        tox.env: py311-mode_ansible-ansible4
+      Ans_311_5:
+        python.version: '3.11'
+        tox.env: py311-mode_ansible-ansible5
+      Ans_311_6:
+        python.version: '3.11'
+        tox.env: py311-mode_ansible-ansible6

--- a/docs/ansible_detailed.rst
+++ b/docs/ansible_detailed.rst
@@ -147,8 +147,8 @@ Noteworthy Differences
 
 * Mitogen 0.2.x supports Ansible 2.3-2.9; with Python 2.6, 2.7, or 3.6.
   Mitogen 0.3.1+ supports
-    - Ansible 2.10, 3, and 4; with Python 2.7, or 3.6-3.10
-    - Ansible 5 and 6; with Python 3.8-3.10
+    - Ansible 2.10, 3, and 4; with Python 2.7, or 3.6-3.11
+    - Ansible 5 and 6; with Python 3.8-3.11
   Verify your installation is running one of these versions by checking
   ``ansible --version`` output.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,8 @@ To avail of fixes in an unreleased version, please download a ZIP file
 Unreleased
 ----------
 
+* :gh:issue:`987` Support Python 3.11
+
 
 v0.3.4 (2023-07-02)
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: System :: Distributed Computing',
         'Topic :: System :: Systems Administration',

--- a/tests/ansible/lib/action/assert_equal.py
+++ b/tests/ansible/lib/action/assert_equal.py
@@ -16,7 +16,12 @@ from ansible.plugins.action import ActionBase
 
 TEMPLATE_KWARGS = {}
 
-_argspec = inspect.getargspec(ansible.template.Templar.template)
+try:
+    # inspect.getfullargspec()  Added: 3.0
+    _argspec = inspect.getfullargspec(ansible.template.Templar.template)
+except AttributeError:
+    # inspect.getargspec()      Added: 2.1  Deprecated: 3.0  Removed: 3.11
+    _argspec = inspect.getargspec(ansible.template.Templar.template)
 if 'bare_deprecated' in _argspec.args:
     TEMPLATE_KWARGS['bare_deprecated'] = False
 

--- a/tests/data/importer/webproject/modules_expected_py3x-new.json
+++ b/tests/data/importer/webproject/modules_expected_py3x-new.json
@@ -201,8 +201,7 @@
       "pytz.exceptions",
       "pytz.lazy",
       "pytz.tzfile",
-      "pytz.tzinfo",
-      "zipimport"
+      "pytz.tzinfo"
     ]
   }
 }

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,11 +1,10 @@
-psutil==5.4.8
+cffi==1.15.1
 coverage==5.5;      python_version < '3.7'
 coverage==6.4.4;    python_version >= '3.7'
 Django==1.11.29;    python_version < '3.0'
 Django==3.2.20;     python_version >= '3.6'
 mock==2.0.0
-cffi==1.14.3  # Random pin to try and fix pyparser==2.18 not having effect
-pycparser==2.18  # Last version supporting 2.6.
+psutil==5.9.5
 pytest-catchlog==1.2.2
 pytest==3.1.2
 subprocess32==3.5.4; python_version < '3.0'

--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -90,7 +90,7 @@ def base_executable(executable=None):
         base_executable = None
 
     if base_executable and base_executable != executable:
-        return 'be', base_executable
+        return base_executable
 
     # Python 2.x only has sys.base_prefix if running outside a virtualenv.
     try:

--- a/tox.ini
+++ b/tox.ini
@@ -34,10 +34,10 @@
 envlist =
     init,
     py{27,36}-mode_ansible-ansible{2.10,3,4},
-    py{310}-mode_ansible-ansible{2.10,3,4,5,6},
-    py{27,36,310}-mode_mitogen-distro_centos{6,7,8},
-    py{27,36,310}-mode_mitogen-distro_debian{9,10,11},
-    py{27,36,310}-mode_mitogen-distro_ubuntu{1604,1804,2004},
+    py{311}-mode_ansible-ansible{2.10,3,4,5,6},
+    py{27,36,311}-mode_mitogen-distro_centos{6,7,8},
+    py{27,36,311}-mode_mitogen-distro_debian{9,10,11},
+    py{27,36,311}-mode_mitogen-distro_ubuntu{1604,1804,2004},
     report,
 
 [testenv]
@@ -50,6 +50,7 @@ basepython =
     py38: python3.8
     py39: python3.9
     py310: python3.10
+    py311: python3.11
 deps =
     -r{toxinidir}/tests/requirements.txt
     mode_ansible: -r{toxinidir}/tests/ansible/requirements.txt


### PR DESCRIPTION
Supercedes #987. Additionally includes testsuite updates, changelog entry, and other fixes.