### PR TITLE
ci: Authenticate UsePythonVersion requests to Github

### DIFF
--- a/.ci/azure-pipelines-steps.yml
+++ b/.ci/azure-pipelines-steps.yml
@@ -9,6 +9,7 @@ steps:
 - task: UsePythonVersion@0
   displayName: Install python
   inputs:
+    githubToken: '$(GITHUB_PYVER_TOKEN)'
     versionSpec: '$(python.version)'
   condition: ne(variables['python.version'], '')
 


### PR DESCRIPTION
This should address the warning in Azure Pipelines

> You should provide GitHub token if you want to download a python release.
> Otherwise you may hit the GitHub anonymous download limit.

The token is provided from a secret variable in the pipeline.