### PR TITLE
Handle missing module file

### DIFF
--- a/mitogen/master.py
+++ b/mitogen/master.py
@@ -137,7 +137,11 @@ def is_stdlib_name(modname):
         return False
 
     # six installs crap with no __file__
-    modpath = os.path.abspath(getattr(module, '__file__', ''))
+    path = getattr(module, '__file__', '')
+    if path is None:
+        path = ''
+
+    modpath = os.path.abspath(path)
     return is_stdlib_path(modpath)
 
 


### PR DESCRIPTION
It's been discovered that some modules have the `__file__` property being set as `None`. An example of a such module is `backports`.

Providing `None` to `os.path.abspath()` causes an exception: `TypeError: expected str, bytes or os.PathLike object, not NoneType`

Related to 
- https://github.com/mitogen-hq/mitogen/issues/946

