### PR TITLE
prefer newer unittest.mock from the standard library

### DIFF
--- a/scripts/pogrep.py
+++ b/scripts/pogrep.py
@@ -6,6 +6,7 @@
 #   - apt-get source libpam0g
 #   - cd */po/
 #   - python ~/pogrep.py "Password: "
+from __future__ import print_function
 
 import sys
 import shlex
@@ -31,7 +32,7 @@ for path in glob.glob('*.po'):
         if last_word == 'msgid' and word == 'msgstr':
             if last_rest == sys.argv[1]:
                 thing = rest.rstrip(': ').decode('utf-8').lower().encode('utf-8').encode('base64').rstrip()
-                print '    %-60s # %s' % (repr(thing)+',', path)
+                print('    %-60s # %s' % (repr(thing)+',', path))
 
         last_word = word
         last_rest = rest

--- a/tests/ansible/tests/connection_test.py
+++ b/tests/ansible/tests/connection_test.py
@@ -2,7 +2,11 @@ from __future__ import absolute_import
 import os
 import tempfile
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 import ansible.errors
 import ansible.playbook.play_context
 

--- a/tests/ansible/tests/target_test.py
+++ b/tests/ansible/tests/target_test.py
@@ -4,7 +4,10 @@ import subprocess
 import tempfile
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import ansible_mitogen.target
 import testlib

--- a/tests/broker_test.py
+++ b/tests/broker_test.py
@@ -1,4 +1,7 @@
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import testlib
 

--- a/tests/importer_test.py
+++ b/tests/importer_test.py
@@ -4,7 +4,10 @@ import types
 import zlib
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import mitogen.core
 import mitogen.utils

--- a/tests/io_op_test.py
+++ b/tests/io_op_test.py
@@ -1,7 +1,10 @@
 import errno
 import select
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import testlib
 import mitogen.core

--- a/tests/log_handler_test.py
+++ b/tests/log_handler_test.py
@@ -1,7 +1,11 @@
 import logging
-import mock
 import sys
 import unittest
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import testlib
 import mitogen.core

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -2,7 +2,10 @@ import sys
 import struct
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import mitogen.core
 import mitogen.master

--- a/tests/mitogen_protocol_test.py
+++ b/tests/mitogen_protocol_test.py
@@ -1,4 +1,7 @@
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import mitogen.core
 

--- a/tests/parent_test.py
+++ b/tests/parent_test.py
@@ -6,7 +6,10 @@ import sys
 import time
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import testlib
 
 import mitogen.core

--- a/tests/policy_function_test.py
+++ b/tests/policy_function_test.py
@@ -1,4 +1,7 @@
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import mitogen.core
 import mitogen.parent

--- a/tests/reaper_test.py
+++ b/tests/reaper_test.py
@@ -1,7 +1,10 @@
 import signal
 
 import testlib
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import mitogen.parent
 

--- a/tests/responder_test.py
+++ b/tests/responder_test.py
@@ -1,8 +1,12 @@
-import mock
 import textwrap
 import subprocess
 import sys
 import unittest
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import mitogen.master
 import testlib

--- a/tests/timer_test.py
+++ b/tests/timer_test.py
@@ -1,4 +1,7 @@
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import mitogen.core
 import mitogen.parent


### PR DESCRIPTION
https://github.com/testing-cabal/mock

mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.
