### PR TITLE
ansible_mitogen: Handle unsafe paths in _remote_chmod

### DIFF
--- a/ansible_mitogen/mixins.py
+++ b/ansible_mitogen/mixins.py
@@ -280,7 +280,9 @@ class ActionModuleMixin(ansible.plugins.action.ActionBase):
                   paths, mode, sudoable)
         return self.fake_shell(lambda: mitogen.select.Select.all(
             self._connection.get_chain().call_async(
-                ansible_mitogen.target.set_file_mode, path, mode
+                ansible_mitogen.target.set_file_mode,
+                ansible_mitogen.utils.unsafe.cast(path),
+                mode,
             )
             for path in paths
         ))

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,8 @@ To avail of fixes in an unreleased version, please download a ZIP file
 Unreleased
 ----------
 
+* :gh:issue:`1087` Fix :exc:`mitogen.core.StreamError` when Ansible template
+  module is called with a ``dest:`` filename that has an extension
 
 
 v0.3.9 (2024-08-13)

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -125,6 +125,7 @@ sponsorship and outstanding future-thinking of its early adopters.
     <li><a href="https://www.channable.com">rkrzr</a></li>
     <li>jgadling</li>
     <li>John F Wall &mdash; <em>Making Ansible Great with Massive Parallelism</em></li>
+    <li><a href="https://github.com/jrosser">Jonathan Rosser</a></li>
     <li>KennethC</li>
     <li><a href="https://github.com/lberruti">Luca Berruti</li>
     <li>Lewis Bellwood &mdash; <em>Happy to be apart of a great project.</em></li>

--- a/tests/ansible/regression/all.yml
+++ b/tests/ansible/regression/all.yml
@@ -16,3 +16,4 @@
 - import_playbook: issue_776__load_plugins_called_twice.yml
 - import_playbook: issue_952__ask_become_pass.yml
 - import_playbook: issue_1066__add_host__host_key_checking.yml
+- import_playbook: issue_1087__template_streamerror.yml

--- a/tests/ansible/regression/issue_1087__template_streamerror.yml
+++ b/tests/ansible/regression/issue_1087__template_streamerror.yml
@@ -1,0 +1,43 @@
+- name: regression/issue_1087__template_streamerror.yml
+  # Ansible's template module has been seen to raise mitogen.core.StreamError
+  # iif  there is a with_items loop and the destination path has an extension.
+  # This printed an error message and left file permissions incorrect,
+  # but did not cause the task/playbook to fail.
+  hosts: test-targets
+  gather_facts: false
+  become: false
+  vars:
+    foos:
+      - dest: /tmp/foo
+      - dest: /tmp/foo.txt
+    foo: Foo
+    bar: Bar
+  tasks:
+    - block:
+        - name: Test template does not cause StreamError
+          delegate_to: localhost
+          run_once: true
+          environment:
+            ANSIBLE_VERBOSITY: "{{ ansible_verbosity }}"
+          command:
+            cmd: >
+              ansible-playbook
+              {% for inv in ansible_inventory_sources %}
+              -i "{{ inv }}"
+              {% endfor %}
+              regression/template_test.yml
+            chdir: ../
+          register: issue_1087_cmd
+          failed_when:
+            - issue_1087_cmd is failed
+              or issue_1087_cmd.stdout is search('ERROR|mitogen\.core\.CallError')
+              or issue_1087_cmd.stderr is search('ERROR|mitogen\.core\.CallError')
+
+      always:
+        - name: Cleanup
+          file:
+            path: "{{ item.dest }}"
+            state: absent
+          with_items: "{{ foos }}"
+  tags:
+    - issue_1087

--- a/tests/ansible/regression/template_test.yml
+++ b/tests/ansible/regression/template_test.yml
@@ -1,0 +1,28 @@
+- name: regression/template_test.yml
+  # Ansible's template module has been seen to raise mitogen.core.StreamError
+  # iif  there is a with_items loop and the destination path has an extension
+  hosts: test-targets
+  gather_facts: false
+  become: false
+  vars:
+    foos:
+      - dest: /tmp/foo
+      - dest: /tmp/foo.txt
+    foo: Foo
+    bar: Bar
+  tasks:
+    - block:
+        - name: Template files
+          template:
+            src: foo.bar.j2
+            dest: "{{ item.dest }}"
+            mode: u=rw,go=r
+          # This has to be with_items, loop: doesn't trigger the bug
+          with_items: "{{ foos }}"
+
+      always:
+        - name: Cleanup
+          file:
+            path: "{{ item.dest }}"
+            state: absent
+          with_items: "{{ foos }}"

--- a/tests/ansible/regression/templates/foo.bar.j2
+++ b/tests/ansible/regression/templates/foo.bar.j2
@@ -1,0 +1,1 @@
+A {{ foo }} walks into a {{ bar }}. Ow!


### PR DESCRIPTION
This is missing from https://github.com/mitogen-hq/mitogen/commit/b822f20007ebe94106b15275962ea4cbbd8a0331

Seems to be only triggered when using `with_items` and the destination filenames have an extension.

The rather surprising behaviour of only failing when there is a filename extension is due to https://github.com/ansible/ansible/blob/906c969b551b346ef54a2c0b41e04f632b7b73c2/lib/ansible/plugins/action/copy.py#L294-L300

The temporary file name created by the copy module gets the source path extension appended if the source file has an extension (i.e. contains a dot). Something in Ansible wraps the filename in an unsafe and because the filename is unsafe, so is the extension pulled from it and therefore so is the temporary file name once the extension gets appended.

```yaml
- hosts: targets
  gather_facts: false
  vars:
    pip_proxy: "test-proxy"
    use_pip_proxy: true
  tasks:
    - name: Create pip.conf if pip_proxy is defined
      template:
        src: pip.conf.j2
        dest: "{{ item }}"
        mode: u=rw,g=r,o=r
      when:
        - pip_proxy is defined
        - pip_proxy | length != 0
        - use_pip_proxy
      with_items:
        - "/tmp/foo.conf"  # <- must have a file extension to fail
        - "/tmp/bar.conf"
```

```python-traceback
Traceback (most recent call last):
  File "/Users/jrosser/cloud/mitogen-richh/mitogen/ansible_mitogen/mixins.py", line 172, in fake_shell
    rc = func()
         ^^^^^^
  File "/Users/jrosser/cloud/mitogen-richh/mitogen/ansible_mitogen/mixins.py", line 281, in <lambda>
    return self.fake_shell(lambda: mitogen.select.Select.all(
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jrosser/cloud/mitogen-richh/mitogen/mitogen/select.py", line 152, in all
    return list(msg.unpickle() for msg in cls(receivers))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jrosser/cloud/mitogen-richh/mitogen/mitogen/select.py", line 152, in <genexpr>
    return list(msg.unpickle() for msg in cls(receivers))
                ^^^^^^^^^^^^^^
  File "/Users/jrosser/cloud/mitogen-richh/mitogen/mitogen/core.py", line 1009, in unpickle
    raise obj
mitogen.core.CallError: mitogen.core.StreamError: cannot unpickle 'ansible.utils.unsafe_proxy'/'AnsibleUnsafeText'
```