### PR TITLE
Fix AnsibleUnsafeText when copying files larger than SMALL_FILE_LIMIT

### DIFF
--- a/ansible_mitogen/connection.py
+++ b/ansible_mitogen/connection.py
@@ -1129,6 +1129,6 @@ class Connection(ansible.plugins.connection.ConnectionBase):
         self.get_chain().call(
             ansible_mitogen.target.transfer_file,
             context=self.binding.get_child_service_context(),
-            in_path=in_path,
-            out_path=out_path
+            in_path=ansible_mitogen.utils.unsafe.cast(in_path),
+            out_path=ansible_mitogen.utils.unsafe.cast(out_path)
         )

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,9 @@ Unreleased
 
 * :gh:issue:`1087` Fix :exc:`mitogen.core.StreamError` when Ansible template
   module is called with a ``dest:`` filename that has an extension
+* :gh:issue:`1110` Fix :exc:`mitogen.core.StreamError` when Ansible copy
+  module is called with a file larger than 124 kibibytes
+  (:data:`ansible_mitogen.connection.Connection.SMALL_FILE_LIMIT`)
 
 
 v0.3.9 (2024-08-13)

--- a/tests/ansible/integration/action/copy.yml
+++ b/tests/ansible/integration/action/copy.yml
@@ -1,4 +1,6 @@
 # Verify copy module for small and large files, and inline content.
+# To exercise https://github.com/mitogen-hq/mitogen/pull/1110 destination
+# files must have extensions and loops must use `with_items:`.
 
 - name: integration/action/copy.yml
   hosts: test-targets
@@ -29,7 +31,7 @@
         dest: "{{ item.src }}"
         content: "{{ item.content }}"
         mode: u=rw,go=r
-      loop: "{{ sourced_files }}"
+      with_items: "{{ sourced_files }}"
       loop_control:
         label: "{{ item.src }}"
       delegate_to: localhost
@@ -39,7 +41,7 @@
       file:
         path: "{{ item.dest }}"
         state: absent
-      loop: "{{ files }}"
+      with_items: "{{ files }}"
       loop_control:
         label: "{{ item.dest }}"
 
@@ -48,7 +50,7 @@
         src: "{{ item.src }}"
         dest: "{{ item.dest }}"
         mode: u=rw,go=r
-      loop: "{{ sourced_files }}"
+      with_items: "{{ sourced_files }}"
       loop_control:
         label: "{{ item.dest }}"
 
@@ -57,7 +59,7 @@
         dest: "{{ item.dest }}"
         content: "{{ item.content }}"
         mode: u=rw,go=r
-      loop: "{{ inline_files }}"
+      with_items: "{{ inline_files }}"
       loop_control:
         label: "{{ item.dest }}"
 
@@ -66,7 +68,7 @@
     - name: Stat copied files
       stat:
         path: "{{ item.dest }}"
-      loop: "{{ files }}"
+      with_items: "{{ files }}"
       loop_control:
         label: "{{ item.dest }}"
       register: stat
@@ -76,7 +78,7 @@
           - item.stat.checksum == item.item.expected_checksum
         quiet: true  # Avoid spamming stdout with 400 kB of item.item.content
         fail_msg: item={{ item }}
-      loop: "{{ stat.results }}"
+      with_items: "{{ stat.results }}"
       loop_control:
         label: "{{ item.stat.path }}"
 
@@ -84,8 +86,9 @@
       file:
         path: "{{ item.dest }}"
         state: absent
-      loop: "{{ files }}"
+      with_items: "{{ files }}"
       loop_control:
         label: "{{ item.dest }}"
   tags:
     - copy
+    - issue_1110

--- a/tests/ansible/integration/action/copy.yml
+++ b/tests/ansible/integration/action/copy.yml
@@ -2,91 +2,90 @@
 
 - name: integration/action/copy.yml
   hosts: test-targets
-  tasks:
-    - name: Create tiny file
-      copy:
-        dest: /tmp/copy-tiny-file
-        content:
-          this is a tiny file.
-      delegate_to: localhost
-      run_once: true
-
-    - name: Create large file
-      copy:
-        dest: /tmp/copy-large-file
-        # Must be larger than Connection.SMALL_SIZE_LIMIT.
-        content: "{% for x in range(200000) %}x{% endfor %}"
-      delegate_to: localhost
-      run_once: true
-
-    - name: Cleanup copied files
-      file:
-        state: absent
-        path: "{{item}}"
-      with_items:
-      - /tmp/copy-tiny-file.out
-      - /tmp/copy-large-file.out
-      - /tmp/copy-tiny-inline-file.out
-      - /tmp/copy-large-inline-file.out
-
-    - name: Copy large file
-      copy:
-        dest: /tmp/copy-large-file.out
-        src: /tmp/copy-large-file
-
-    - name: Copy tiny file
-      copy:
+  vars:
+    sourced_files:
+      - src: /tmp/copy-tiny-file
         dest: /tmp/copy-tiny-file.out
-        src: /tmp/copy-tiny-file
+        content: this is a tiny file.
+        expected_checksum: f29faa9a6f19a700a941bf2aa5b281643c4ec8a0
+      - src: /tmp/copy-large-file
+        dest: /tmp/copy-large-file.out
+        content: "{{ 'x' * 200000 }}"
+        expected_checksum: 62951f943c41cdd326e5ce2b53a779e7916a820d
 
-    - name: Copy tiny inline file
-      copy:
-        dest: /tmp/copy-tiny-inline-file.out
-        content: "tiny inline content"
-
-    - name: Copy large inline file
-      copy:
-        dest: /tmp/copy-large-inline-file.out
+    inline_files:
+      - dest: /tmp/copy-tiny-inline-file.out
+        content: tiny inline content
+        expected_checksum: b26dd6444595e2bdb342aa0a91721b57478b5029
+      - dest: /tmp/copy-large-inline-file.out
         content: |
-          {% for x in range(200000) %}y{% endfor %}
+          {{ 'y' * 200000 }}
+        expected_checksum: d675f47e467eae19e49032a2cc39118e12a6ee72
+
+    files: "{{ sourced_files + inline_files }}"
+  tasks:
+    - name: Create sourced files
+      copy:
+        dest: "{{ item.src }}"
+        content: "{{ item.content }}"
+        mode: u=rw,go=r
+      loop: "{{ sourced_files }}"
+      loop_control:
+        label: "{{ item.src }}"
+      delegate_to: localhost
+      run_once: true
+
+    - name: Cleanup lingering destination files
+      file:
+        path: "{{ item.dest }}"
+        state: absent
+      loop: "{{ files }}"
+      loop_control:
+        label: "{{ item.dest }}"
+
+    - name: Copy sourced files
+      copy:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+        mode: u=rw,go=r
+      loop: "{{ sourced_files }}"
+      loop_control:
+        label: "{{ item.dest }}"
+
+    - name: Copy inline files
+      copy:
+        dest: "{{ item.dest }}"
+        content: "{{ item.content }}"
+        mode: u=rw,go=r
+      loop: "{{ inline_files }}"
+      loop_control:
+        label: "{{ item.dest }}"
 
     # stat results
 
     - name: Stat copied files
       stat:
-        path: "{{item}}"
-      with_items:
-      - /tmp/copy-tiny-file.out
-      - /tmp/copy-large-file.out
-      - /tmp/copy-tiny-inline-file.out
-      - /tmp/copy-large-inline-file.out
+        path: "{{ item.dest }}"
+      loop: "{{ files }}"
+      loop_control:
+        label: "{{ item.dest }}"
       register: stat
 
     - assert:
         that:
-        - stat.results[0].stat.checksum == "f29faa9a6f19a700a941bf2aa5b281643c4ec8a0"
-        - stat.results[1].stat.checksum == "62951f943c41cdd326e5ce2b53a779e7916a820d"
-        - stat.results[2].stat.checksum == "b26dd6444595e2bdb342aa0a91721b57478b5029"
-        - stat.results[3].stat.checksum == "d675f47e467eae19e49032a2cc39118e12a6ee72"
-        fail_msg: stat={{stat}}
+          - item.stat.checksum == item.item.expected_checksum
+        quiet: true  # Avoid spamming stdout with 400 kB of item.item.content
+        fail_msg: item={{ item }}
+      loop: "{{ stat.results }}"
+      loop_control:
+        label: "{{ item.stat.path }}"
 
-    - name: Cleanup files
+    - name: Cleanup destination files
       file:
+        path: "{{ item.dest }}"
         state: absent
-        path: "{{item}}"
-      with_items:
-      - /tmp/copy-tiny-file
-      - /tmp/copy-tiny-file.out
-      - /tmp/copy-no-mode
-      - /tmp/copy-no-mode.out
-      - /tmp/copy-with-mode
-      - /tmp/copy-with-mode.out
-      - /tmp/copy-large-file
-      - /tmp/copy-large-file.out
-      - /tmp/copy-tiny-inline-file.out
-      - /tmp/copy-large-inline-file
-      - /tmp/copy-large-inline-file.out
-
-    # end of cleaning out files (again)
+      loop: "{{ files }}"
+      loop_control:
+        label: "{{ item.dest }}"
   tags:
     - copy


### PR DESCRIPTION
Small files are carried in-band in the communication between controller and remote, with larger files being copied by falling back to `transfer_file()`. This second code path was missed in b822f20.

Reproducer extracted from original code that failed:

Make the files larger than 2^17 bytes to trigger a failure

```yaml
- hosts: all
  vars:
    atftpd_path: /srv/tftp
    tftp_ipxe_binaries:
      x86_bios: ipxe/x86_64_undionly.kpxe
      x86_uefi: ipxe/x86_64_ipxe.efi
      arm64_uefi: ipxe/arm64_ipxe.efi
  tasks:
    - copy:
        src: "{{ item.value }}"
        dest: "{{ atftpd_path }}/ipxe_{{ item.key }}.bin"
      with_items:
        - "{{ tftp_ipxe_binaries | dict2items }}"
```

Exception:

```
The full traceback is:
Traceback (most recent call last):
  File "/root/venv/lib/python3.10/site-packages/ansible/executor/task_executor.py", line 119, in run
    item_results = self._run_loop(items)
  File "/root/venv/lib/python3.10/site-packages/ansible/executor/task_executor.py", line 334, in _run_loop
    res = self._execute(variables=task_vars)
  File "/root/venv/lib/python3.10/site-packages/ansible/executor/task_executor.py", line 636, in _execute
    result = self._handler.run(task_vars=vars_copy)
  File "/home/ubuntu/mitogen/ansible_mitogen/mixins.py", line 146, in run
    return super(ActionModuleMixin, self).run(tmp, task_vars)
  File "/root/venv/lib/python3.10/site-packages/ansible/plugins/action/copy.py", line 522, in run
    module_return = self._copy_file(source_full, source_rel, content, content_tempfile, dest, task_vars, follow)
  File "/root/venv/lib/python3.10/site-packages/ansible/plugins/action/copy.py", line 305, in _copy_file
    remote_path = self._transfer_file(source_full, tmp_src)
  File "/root/venv/lib/python3.10/site-packages/ansible/plugins/action/__init__.py", line 556, in _transfer_file
    self._connection.put_file(local_path, remote_path)
  File "/home/ubuntu/mitogen/ansible_mitogen/connection.py", line 1129, in put_file
    self.get_chain().call(
  File "/home/ubuntu/mitogen/ansible_mitogen/connection.py", line 466, in call
    return self._rethrow(recv)
  File "/home/ubuntu/mitogen/ansible_mitogen/connection.py", line 452, in _rethrow
    return recv.get().unpickle()
  File "/home/ubuntu/mitogen/mitogen/core.py", line 1009, in unpickle
    raise obj
mitogen.core.CallError: mitogen.core.StreamError: cannot unpickle 'ansible.utils.unsafe_proxy'/'AnsibleUnsafeText'
  File "<stdin>", line 3860, in _dispatch_one
  File "<stdin>", line 3843, in _parse_request
  File "<stdin>", line 998, in unpickle
  File "<stdin>", line 789, in find_class
  File "<stdin>", line 899, in _find_global

fatal: [foobar]: FAILED! => {
    "msg": "Unexpected failure during module execution: mitogen.core.StreamError: cannot unpickle 'ansible.utils.unsafe_proxy'/'AnsibleUnsafeText'\n  File \"<stdin>\", line 3860, in _dispatch_one\n  File \"<stdin>\", line 3843, in _parse_request\n  File \"<stdin>\", line 998, in unpickle\n  File \"<stdin>\", line 789, in find_class\n  File \"<stdin>\", line 899, in _find_global\n",
    "stdout": ""
}
```
