### PR TITLE
ci: Drop macOS Python 3.12 + Ansible 9 tests

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -28,10 +28,6 @@ jobs:
     matrix:
       Mito_312:
         tox.env: py312-mode_mitogen
-      Loc_312_9:
-        tox.env: py312-mode_localhost-ansible9
-      Van_312_9:
-        tox.env: py312-mode_localhost-ansible9-strategy_linear
       Loc_312_10:
         tox.env: py312-mode_localhost-ansible10
       Van_312_10:


### PR DESCRIPTION
They were meant to be replaced by Python 3.12 + ANsible 10, not supplemented.