### PR TITLE
CI: Reliability, eliminate a race condition and some resource leaks

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,6 +29,8 @@ Unreleased
 * :gh:issue:`905` Initial support for templated ``ansible_ssh_args``,
   ``ansible_ssh_common_args``, and ``ansible_ssh_extra_args`` variables.
   NB: play or task scoped variables will probably still fail.
+* :gh:issue:`694` CI: Fixed a race condition and some resource leaks causing
+  some of intermittent failures when running the test suite.
 
 
 v0.3.9 (2024-08-13)

--- a/mitogen/parent.py
+++ b/mitogen/parent.py
@@ -2542,7 +2542,7 @@ class Reaper(object):
         # because it is setuid, so this is best-effort only.
         LOG.debug('%r: sending %s', self.proc, SIGNAL_BY_NUM[signum])
         try:
-            os.kill(self.proc.pid, signum)
+            self.proc.send_signal(signum)
         except OSError:
             e = sys.exc_info()[1]
             if e.args[0] != errno.EPERM:
@@ -2662,6 +2662,17 @@ class Process(object):
         """
         raise NotImplementedError()
 
+    def send_signal(self, sig):
+        os.kill(self.pid, sig)
+
+    def terminate(self):
+        "Ask the process to gracefully shutdown."
+        self.send_signal(signal.SIGTERM)
+
+    def kill(self):
+        "Ask the operating system to forcefully destroy the process."
+        self.send_signal(signal.SIGKILL)
+
 
 class PopenProcess(Process):
     """
@@ -2677,6 +2688,9 @@ class PopenProcess(Process):
 
     def poll(self):
         return self.proc.poll()
+
+    def send_signal(self, sig):
+        self.proc.send_signal(sig)
 
 
 class ModuleForwarder(object):

--- a/tests/connection_test.py
+++ b/tests/connection_test.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import signal
 import sys

--- a/tests/create_child_test.py
+++ b/tests/create_child_test.py
@@ -76,6 +76,7 @@ def close_proc(proc):
     proc.stdout.close()
     if proc.stderr:
         proc.stderr.close()
+    proc.proc.wait()
 
 
 def wait_read(fp, n):

--- a/tests/data/importer/six_brokenpkg/__init__.py
+++ b/tests/data/importer/six_brokenpkg/__init__.py
@@ -53,4 +53,4 @@ if _system_six:
 else:
     from . import _six as six
 six_py_file = '{0}.py'.format(os.path.splitext(six.__file__)[0])
-exec(open(six_py_file, 'rb').read())
+with open(six_py_file, 'rb') as f: exec(f.read())

--- a/tests/id_allocation_test.py
+++ b/tests/id_allocation_test.py
@@ -27,3 +27,6 @@ class SlaveTest(testlib.RouterMixin, testlib.TestCase):
         # Subsequent master allocation does not collide
         c2 = self.router.local()
         self.assertEqual(1002, c2.context_id)
+
+        context.shutdown()
+        c2.shutdown()

--- a/tests/reaper_test.py
+++ b/tests/reaper_test.py
@@ -10,8 +10,7 @@ import mitogen.parent
 
 
 class ReaperTest(testlib.TestCase):
-    @mock.patch('os.kill')
-    def test_calc_delay(self, kill):
+    def test_calc_delay(self):
         broker = mock.Mock()
         proc = mock.Mock()
         proc.poll.return_value = None
@@ -24,8 +23,7 @@ class ReaperTest(testlib.TestCase):
         self.assertEqual(752, int(1000 * reaper._calc_delay(5)))
         self.assertEqual(1294, int(1000 * reaper._calc_delay(6)))
 
-    @mock.patch('os.kill')
-    def test_reap_calls(self, kill):
+    def test_reap_calls(self):
         broker = mock.Mock()
         proc = mock.Mock()
         proc.poll.return_value = None
@@ -33,20 +31,20 @@ class ReaperTest(testlib.TestCase):
         reaper = mitogen.parent.Reaper(broker, proc, True, True)
 
         reaper.reap()
-        self.assertEqual(0, kill.call_count)
+        self.assertEqual(0, proc.send_signal.call_count)
 
         reaper.reap()
-        self.assertEqual(1, kill.call_count)
+        self.assertEqual(1, proc.send_signal.call_count)
 
         reaper.reap()
         reaper.reap()
         reaper.reap()
-        self.assertEqual(1, kill.call_count)
+        self.assertEqual(1, proc.send_signal.call_count)
 
         reaper.reap()
-        self.assertEqual(2, kill.call_count)
+        self.assertEqual(2, proc.send_signal.call_count)
 
-        self.assertEqual(kill.mock_calls, [
-            mock.call(proc.pid, signal.SIGTERM),
-            mock.call(proc.pid, signal.SIGKILL),
+        self.assertEqual(proc.send_signal.mock_calls, [
+            mock.call(signal.SIGTERM),
+            mock.call(signal.SIGKILL),
         ])

--- a/tests/ssh_test.py
+++ b/tests/ssh_test.py
@@ -190,6 +190,7 @@ class BannerTest(testlib.DockerMixin, testlib.TestCase):
             self.dockerized_ssh.port,
         )
         self.assertEqual(name, context.name)
+        context.shutdown(wait=True)
 
 
 class StubPermissionDeniedTest(StubSshMixin, testlib.TestCase):

--- a/tests/unix_test.py
+++ b/tests/unix_test.py
@@ -65,17 +65,13 @@ class ListenerTest(testlib.RouterMixin, testlib.TestCase):
 
     def test_constructor_basic(self):
         listener = self.klass.build_stream(router=self.router)
-        capture = testlib.LogCapturer()
-        capture.start()
-        try:
-            self.assertFalse(mitogen.unix.is_path_dead(listener.protocol.path))
-            os.unlink(listener.protocol.path)
-            # ensure we catch 0 byte read error log message
-            self.broker.shutdown()
-            self.broker.join()
-            self.broker_shutdown = True
-        finally:
-            capture.stop()
+        self.assertFalse(mitogen.unix.is_path_dead(listener.protocol.path))
+        os.unlink(listener.protocol.path)
+
+        # ensure we catch 0 byte read error log message
+        self.broker.shutdown()
+        self.broker.join()
+        self.broker_shutdown = True
 
 
 class ClientTest(testlib.TestCase):


### PR DESCRIPTION
This improves the situation wrt #1058. It should eliminate the most painful intermittent failure

> AssertionError: Docker container 'mitogen-test-...' contained extra running processes after test completed

fixes #694 