### PR TITLE
Consolidate backward compatibility imports and polyfills

### DIFF
--- a/ansible_mitogen/affinity.py
+++ b/ansible_mitogen/affinity.py
@@ -83,7 +83,6 @@ import multiprocessing
 import os
 import struct
 
-import mitogen.core
 import mitogen.parent
 
 
@@ -265,7 +264,7 @@ class LinuxPolicy(FixedPolicy):
         for x in range(16):
             chunks.append(struct.pack('<Q', mask & shiftmask))
             mask >>= 64
-        return mitogen.core.b('').join(chunks)
+        return b''.join(chunks)
 
     def _get_thread_ids(self):
         try:

--- a/ansible_mitogen/logging.py
+++ b/ansible_mitogen/logging.py
@@ -32,15 +32,13 @@ __metaclass__ = type
 import logging
 import os
 
+import ansible.utils.display
+
 import mitogen.core
 import mitogen.utils
 
-try:
-    from __main__ import display
-except ImportError:
-    import ansible.utils.display
-    display = ansible.utils.display.Display()
 
+display = ansible.utils.display.Display()
 
 #: The process name set via :func:`set_process_name`.
 _process_name = None

--- a/ansible_mitogen/mixins.py
+++ b/ansible_mitogen/mixins.py
@@ -35,11 +35,6 @@ import pwd
 import random
 import traceback
 
-try:
-    from shlex import quote as shlex_quote
-except ImportError:
-    from pipes import quote as shlex_quote
-
 import ansible
 import ansible.constants
 import ansible.plugins
@@ -48,6 +43,7 @@ import ansible.utils.unsafe_proxy
 import ansible.vars.clean
 
 from ansible.module_utils.common.text.converters import to_bytes, to_text
+from ansible.module_utils.six.moves import shlex_quote
 from ansible.parsing.utils.jsonify import jsonify
 
 import mitogen.core

--- a/ansible_mitogen/mixins.py
+++ b/ansible_mitogen/mixins.py
@@ -40,13 +40,15 @@ try:
 except ImportError:
     from pipes import quote as shlex_quote
 
-from ansible.module_utils._text import to_bytes
-from ansible.parsing.utils.jsonify import jsonify
-
 import ansible
 import ansible.constants
 import ansible.plugins
 import ansible.plugins.action
+import ansible.utils.unsafe_proxy
+import ansible.vars.clean
+
+from ansible.module_utils.common.text.converters import to_bytes, to_text
+from ansible.parsing.utils.jsonify import jsonify
 
 import mitogen.core
 import mitogen.select
@@ -56,24 +58,6 @@ import ansible_mitogen.planner
 import ansible_mitogen.target
 import ansible_mitogen.utils
 import ansible_mitogen.utils.unsafe
-
-from ansible.module_utils._text import to_text
-
-try:
-    from ansible.utils.unsafe_proxy import wrap_var
-except ImportError:
-    from ansible.vars.unsafe_proxy import wrap_var
-
-try:
-    # ansible 2.8 moved remove_internal_keys to the clean module
-    from ansible.vars.clean import remove_internal_keys
-except ImportError:
-    try:
-        from ansible.vars.manager import remove_internal_keys
-    except ImportError:
-        # ansible 2.3.3 has remove_internal_keys as a protected func on the action class
-        # we'll fallback to calling self._remove_internal_keys in this case
-        remove_internal_keys = lambda a: "Not found"
 
 
 LOG = logging.getLogger(__name__)
@@ -413,10 +397,7 @@ class ActionModuleMixin(ansible.plugins.action.ActionBase):
             self._remove_tmp_path(tmp)
 
         # prevents things like discovered_interpreter_* or ansible_discovered_interpreter_* from being set
-        # handle ansible 2.3.3 that has remove_internal_keys in a different place
-        check = remove_internal_keys(result)
-        if check == 'Not found':
-            self._remove_internal_keys(result)
+        ansible.vars.clean.remove_internal_keys(result)
 
         # taken from _execute_module of ansible 2.8.6
         # propagate interpreter discovery results back to the controller
@@ -440,7 +421,7 @@ class ActionModuleMixin(ansible.plugins.action.ActionBase):
                 result['deprecations'] = []
             result['deprecations'].extend(self._discovery_deprecation_warnings)
 
-        return wrap_var(result)
+        return ansible.utils.unsafe_proxy.wrap_var(result)
 
     def _postprocess_response(self, result):
         """

--- a/ansible_mitogen/planner.py
+++ b/ansible_mitogen/planner.py
@@ -477,7 +477,7 @@ def read_file(path):
     finally:
         os.close(fd)
 
-    return mitogen.core.b('').join(bits)
+    return b''.join(bits)
 
 
 def _propagate_deps(invocation, planner, context):

--- a/ansible_mitogen/plugins/connection/mitogen_local.py
+++ b/ansible_mitogen/plugins/connection/mitogen_local.py
@@ -42,13 +42,7 @@ except ImportError:
 import ansible_mitogen.connection
 import ansible_mitogen.process
 
-
-if sys.version_info > (3,):
-    viewkeys = dict.keys
-elif sys.version_info > (2, 7):
-    viewkeys = dict.viewkeys
-else:
-    viewkeys = lambda dct: set(dct)
+viewkeys = getattr(dict, 'viewkeys', dict.keys)
 
 
 def dict_diff(old, new):

--- a/ansible_mitogen/process.py
+++ b/ansible_mitogen/process.py
@@ -61,10 +61,9 @@ import mitogen.utils
 import ansible
 import ansible.constants as C
 import ansible.errors
+
 import ansible_mitogen.logging
 import ansible_mitogen.services
-
-from mitogen.core import b
 import ansible_mitogen.affinity
 
 
@@ -639,7 +638,7 @@ class MuxProcess(object):
 
         try:
             # Let the parent know our listening socket is ready.
-            mitogen.core.io_op(self.model.child_sock.send, b('1'))
+            mitogen.core.io_op(self.model.child_sock.send, b'1')
             # Block until the socket is closed, which happens on parent exit.
             mitogen.core.io_op(self.model.child_sock.recv, 1)
         finally:

--- a/ansible_mitogen/runner.py
+++ b/ansible_mitogen/runner.py
@@ -52,6 +52,8 @@ import tempfile
 import traceback
 import types
 
+from ansible.module_utils.six.moves import shlex_quote
+
 import mitogen.core
 import ansible_mitogen.target  # TODO: circular import
 from mitogen.core import to_text
@@ -70,12 +72,6 @@ try:
 except ImportError:
     from io import StringIO
 
-try:
-    from shlex import quote as shlex_quote
-except ImportError:
-    from pipes import quote as shlex_quote
-
-
 # Prevent accidental import of an Ansible module from hanging on stdin read.
 import ansible.module_utils.basic
 ansible.module_utils.basic._ANSIBLE_ARGS = '{}'
@@ -92,7 +88,6 @@ for symbol in 'res_init', '__res_init':
     except AttributeError:
         pass
 
-iteritems = getattr(dict, 'iteritems', dict.items)
 LOG = logging.getLogger(__name__)
 
 
@@ -600,7 +595,7 @@ class TemporaryEnvironment(object):
     def __init__(self, env=None):
         self.original = dict(os.environ)
         self.env = env or {}
-        for key, value in iteritems(self.env):
+        for key, value in mitogen.core.iteritems(self.env):
             key = mitogen.core.to_text(key)
             value = mitogen.core.to_text(value)
             if value is None:

--- a/ansible_mitogen/services.py
+++ b/ansible_mitogen/services.py
@@ -50,6 +50,8 @@ import threading
 
 import ansible.constants
 
+from ansible.module_utils.six import reraise
+
 import mitogen.core
 import mitogen.service
 import ansible_mitogen.loaders
@@ -64,20 +66,6 @@ LOG = logging.getLogger(__name__)
 # during module import to ensure a single-threaded environment; PluginLoader
 # is not thread-safe.
 ansible_mitogen.loaders.shell_loader.get('sh')
-
-
-if sys.version_info[0] == 3:
-    def reraise(tp, value, tb):
-        if value is None:
-            value = tp()
-        if value.__traceback__ is not tb:
-            raise value.with_traceback(tb)
-        raise value
-else:
-    exec(
-        "def reraise(tp, value, tb=None):\n"
-        "    raise tp, value, tb\n"
-     )
 
 
 def _get_candidate_temp_dirs():

--- a/ansible_mitogen/target.py
+++ b/ansible_mitogen/target.py
@@ -39,6 +39,7 @@ __metaclass__ = type
 import errno
 import grp
 import json
+import logging
 import operator
 import os
 import pwd
@@ -51,25 +52,14 @@ import tempfile
 import traceback
 import types
 
-# Absolute imports for <2.5.
-logging = __import__('logging')
-
 import mitogen.core
 import mitogen.parent
 import mitogen.service
-from mitogen.core import b
-
 try:
     reduce
 except NameError:
     # Python 3.x.
     from functools import reduce
-
-try:
-    BaseException
-except NameError:
-    # Python 2.4
-    BaseException = Exception
 
 
 # Ansible since PR #41749 inserts "import __main__" into
@@ -615,8 +605,8 @@ def exec_args(args, in_data='', chdir=None, shell=None, emulate_tty=False):
     stdout, stderr = proc.communicate(in_data)
 
     if emulate_tty:
-        stdout = stdout.replace(b('\n'), b('\r\n'))
-    return proc.returncode, stdout, stderr or b('')
+        stdout = stdout.replace(b'\n', b'\r\n')
+    return proc.returncode, stdout, stderr or b''
 
 
 def exec_command(cmd, in_data='', chdir=None, shell=None, emulate_tty=False):

--- a/ansible_mitogen/target.py
+++ b/ansible_mitogen/target.py
@@ -746,9 +746,7 @@ def set_file_mode(path, spec, fd=None):
     """
     Update the permissions of a file using the same syntax as chmod(1).
     """
-    if isinstance(spec, int):
-        new_mode = spec
-    elif not mitogen.core.PY3 and isinstance(spec, long):
+    if isinstance(spec, mitogen.core.integer_types):
         new_mode = spec
     elif spec.isdigit():
         new_mode = int(spec, 8)

--- a/ansible_mitogen/target.py
+++ b/ansible_mitogen/target.py
@@ -55,12 +55,6 @@ import types
 import mitogen.core
 import mitogen.parent
 import mitogen.service
-try:
-    reduce
-except NameError:
-    # Python 3.x.
-    from functools import reduce
-
 
 # Ansible since PR #41749 inserts "import __main__" into
 # ansible.module_utils.basic. Mitogen's importer will refuse such an import, so
@@ -70,6 +64,9 @@ if not sys.modules.get(str('__main__')):
     sys.modules[str('__main__')] = types.ModuleType(str('__main__'))
 
 import ansible.module_utils.json_utils
+
+from ansible.module_utils.six.moves import reduce
+
 import ansible_mitogen.runner
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,8 @@ To avail of fixes in an unreleased version, please download a ZIP file
 Unreleased
 ----------
 
+* :gh:issue:`1127` :mod:`mitogen`: Consolidate mitogen backward compatibility
+  fallbacks and polyfills into :mod:`mitogen.core`
 
 
 v0.3.10 (2024-09-20)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,8 @@ Unreleased
   fallbacks and polyfills into :mod:`mitogen.core`
 * :gh:issue:`1127` :mod:`ansible_mitogen`: Remove backward compatibility
   fallbacks for Python 2.4 & 2.5.
+* :gh:issue:`1127` :mod:`ansible_mitogen`: Remove fallback imports for Ansible
+  releases before 2.10
 
 
 v0.3.10 (2024-09-20)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,8 @@ Unreleased
 
 * :gh:issue:`1127` :mod:`mitogen`: Consolidate mitogen backward compatibility
   fallbacks and polyfills into :mod:`mitogen.core`
+* :gh:issue:`1127` :mod:`ansible_mitogen`: Remove backward compatibility
+  fallbacks for Python 2.4 & 2.5.
 
 
 v0.3.10 (2024-09-20)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,8 @@ Unreleased
   fallbacks for Python 2.4 & 2.5.
 * :gh:issue:`1127` :mod:`ansible_mitogen`: Remove fallback imports for Ansible
   releases before 2.10
+* :gh:issue:`1127` :mod:`ansible_mitogen`: Consolidate Python 2 & 3
+  compatibility
 
 
 v0.3.10 (2024-09-20)

--- a/mitogen/master.py
+++ b/mitogen/master.py
@@ -74,26 +74,17 @@ import mitogen.core
 import mitogen.minify
 import mitogen.parent
 
+from mitogen.core import any
 from mitogen.core import b
 from mitogen.core import IOLOG
 from mitogen.core import LOG
+from mitogen.core import next
 from mitogen.core import str_partition
 from mitogen.core import str_rpartition
 from mitogen.core import to_text
 
 imap = getattr(itertools, 'imap', map)
 izip = getattr(itertools, 'izip', zip)
-
-try:
-    any
-except NameError:
-    from mitogen.core import any
-
-try:
-    next
-except NameError:
-    from mitogen.core import next
-
 
 RLOG = logging.getLogger('mitogen.ctx')
 

--- a/mitogen/parent.py
+++ b/mitogen/parent.py
@@ -56,15 +56,13 @@ import zlib
 # Absolute imports for <2.5.
 select = __import__('select')
 
-try:
-    import thread
-except ImportError:
-    import threading as thread
-
 import mitogen.core
 from mitogen.core import b
 from mitogen.core import bytes_partition
 from mitogen.core import IOLOG
+from mitogen.core import itervalues
+from mitogen.core import next
+from mitogen.core import thread
 
 
 LOG = logging.getLogger(__name__)
@@ -79,15 +77,6 @@ try:
 except IOError:
     SELINUX_ENABLED = False
 
-
-try:
-    next
-except NameError:
-    # Python 2.4/2.5
-    from mitogen.core import next
-
-
-itervalues = getattr(dict, 'itervalues', dict.values)
 
 if mitogen.core.PY3:
     xrange = range

--- a/mitogen/service.py
+++ b/mitogen/service.py
@@ -39,17 +39,9 @@ import threading
 
 import mitogen.core
 import mitogen.select
+from mitogen.core import all
 from mitogen.core import b
 from mitogen.core import str_rpartition
-
-try:
-    all
-except NameError:
-    def all(it):
-        for elem in it:
-            if not elem:
-                return False
-        return True
 
 
 LOG = logging.getLogger(__name__)

--- a/mitogen/ssh.py
+++ b/mitogen/ssh.py
@@ -43,11 +43,6 @@ except ImportError:
 import mitogen.parent
 from mitogen.core import b
 
-try:
-    any
-except NameError:
-    from mitogen.core import any
-
 
 LOG = logging.getLogger(__name__)
 

--- a/mitogen/su.py
+++ b/mitogen/su.py
@@ -34,11 +34,6 @@ import re
 import mitogen.core
 import mitogen.parent
 
-try:
-    any
-except NameError:
-    from mitogen.core import any
-
 
 LOG = logging.getLogger(__name__)
 

--- a/mitogen/utils.py
+++ b/mitogen/utils.py
@@ -37,13 +37,7 @@ import sys
 import mitogen.core
 import mitogen.master
 
-
-iteritems = getattr(dict, 'iteritems', dict.items)
-
-if mitogen.core.PY3:
-    iteritems = dict.items
-else:
-    iteritems = dict.iteritems
+from mitogen.core import iteritems
 
 
 def setup_gil():

--- a/tests/ansible/lib/modules/custom_python_detect_environment.py
+++ b/tests/ansible/lib/modules/custom_python_detect_environment.py
@@ -11,17 +11,6 @@ import socket
 import sys
 
 
-try:
-    all
-except NameError:
-    # Python 2.4
-    def all(it):
-        for elem in it:
-            if not elem:
-                return False
-        return True
-
-
 def main():
     module = AnsibleModule(argument_spec={})
     module.exit_json(

--- a/tests/connection_test.py
+++ b/tests/connection_test.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import signal
 import sys
 import tempfile
 import threading

--- a/tests/iter_split_test.py
+++ b/tests/iter_split_test.py
@@ -2,11 +2,7 @@ import unittest
 
 import mitogen.core
 
-try:
-    next
-except NameError:
-    def next(it):
-        return it.next()
+from mitogen.core import next
 
 
 class IterSplitTest(unittest.TestCase):

--- a/tests/lxc_test.py
+++ b/tests/lxc_test.py
@@ -3,10 +3,7 @@ import os
 import mitogen.lxc
 import mitogen.parent
 
-try:
-    any
-except NameError:
-    from mitogen.core import any
+from mitogen.core import any
 
 import testlib
 

--- a/tests/poller_test.py
+++ b/tests/poller_test.py
@@ -8,13 +8,9 @@ import unittest
 import mitogen.core
 import mitogen.parent
 
-import testlib
+from mitogen.core import next
 
-try:
-    next
-except NameError:
-    # Python 2.4
-    from mitogen.core import next
+import testlib
 
 
 class SockMixin(object):

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,9 @@
 # ansible == 9.x     ansible-core ~= 2.16.0
 # ansible == 10.x    ansible-core ~= 2.17.0
 
+# See also
+# - https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
+
 [tox]
 envlist =
     init,


### PR DESCRIPTION
- Consolidates Python 2.4 imports/polyfills in `mitogen.core`
- Removes Python < 2.6 backward compatibility imports/polyfills from `ansible_mitogen`
- Removes Ansible < 2.10 backward compatibility imports/polyfills from `ansible_mitogen`