### PR TITLE
tests: Improve Ansible fail_msg formatting

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,7 @@ Unreleased
 
 * :gh:issue:`1106` :mod:`ansible_mitogen`: Support for `ansible_ssh_password`
   connection variable, and templated SSH connection password.
+* :gh:issue:`1136` tests: Improve Ansible fail_msg formatting.
 
 
 v0.3.11 (2024-10-30)

--- a/tests/ansible/integration/action/copy.yml
+++ b/tests/ansible/integration/action/copy.yml
@@ -77,7 +77,8 @@
         that:
           - item.stat.checksum == item.item.expected_checksum
         quiet: true  # Avoid spamming stdout with 400 kB of item.item.content
-        fail_msg: item={{ item }}
+        fail_msg: |
+          item={{ item }}
       with_items: "{{ stat.results }}"
       loop_control:
         label: "{{ item.stat.path }}"

--- a/tests/ansible/integration/action/fixup_perms2__copy.yml
+++ b/tests/ansible/integration/action/fixup_perms2__copy.yml
@@ -16,7 +16,8 @@
     - assert:
         that:
         -  out.stat.mode in ("0644", "0664")
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - name: "Copy files from content: arg"
       copy:
@@ -29,7 +30,8 @@
     - assert:
         that:
         -  out.stat.mode == "0400"
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - name: Cleanup local weird mode file
       file:
@@ -55,7 +57,8 @@
     - assert:
         that:
         - out.stat.mode in ("0644", "0664")
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - name: Copy file with weird mode, preserving mode
       copy:
@@ -69,7 +72,8 @@
     - assert:
         that:
         - out.stat.mode == "1462"
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - name: Copy file with weird mode, explicit mode
       copy:
@@ -84,7 +88,8 @@
     - assert:
         that:
         - out.stat.mode == "1461"
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - name: Cleanup
       file:

--- a/tests/ansible/integration/action/low_level_execute_command.yml
+++ b/tests/ansible/integration/action/low_level_execute_command.yml
@@ -15,7 +15,8 @@
           - 'raw.rc == 0'
           - 'raw.stdout_lines[-1]|to_text == "2"'
           - 'raw.stdout[-1]|to_text == "2"'
-        fail_msg: raw={{raw}}
+        fail_msg: |
+          raw={{ raw }}
 
     - name: Run raw module with sudo
       become: true
@@ -39,6 +40,7 @@
             ["root\r\n"],
             ["root"],
           )
-        fail_msg: raw={{raw}}
+        fail_msg: |
+          raw={{ raw }}
   tags:
     - low_level_execute_command

--- a/tests/ansible/integration/action/make_tmp_path.yml
+++ b/tests/ansible/integration/action/make_tmp_path.yml
@@ -42,13 +42,17 @@
       assert:
         that:
         - good_temp_path == good_temp_path2
-        fail_msg: good_temp_path={{good_temp_path}} good_temp_path2={{good_temp_path2}}
+        fail_msg: |
+          good_temp_path={{ good_temp_path }}
+          good_temp_path2={{ good_temp_path2 }}
 
     - name: "Verify different subdir for both tasks"
       assert:
         that:
         - tmp_path.path != tmp_path2.path
-        fail_msg: tmp_path={{tmp_path}} tmp_path2={{tmp_path2}}
+        fail_msg: |
+          tmp_path={{ tmp_path }}
+          tmp_path2={{ tmp_path2 }}
 
     #
     # Verify subdirectory removal.
@@ -69,7 +73,9 @@
         that:
         - not stat1.stat.exists
         - not stat2.stat.exists
-        fail_msg: stat1={{stat1}} stat2={{stat2}}
+        fail_msg: |
+          stat1={{ stat1 }}
+          stat2={{ stat2 }}
 
     #
     # Verify good directory persistence.
@@ -84,7 +90,8 @@
       assert:
         that:
         - stat.stat.exists
-        fail_msg: stat={{stat}}
+        fail_msg: |
+          stat={{ stat }}
 
     #
     # Write some junk into the temp path.
@@ -107,7 +114,8 @@
     - assert:
         that:
         - not out.stat.exists
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     #
     # root
@@ -126,7 +134,9 @@
         that:
         - tmp_path2.path != tmp_path_root.path
         - tmp_path2.path|dirname != tmp_path_root.path|dirname
-        fail_msg: tmp_path_root={{tmp_path_root}} tmp_path2={{tmp_path2}}
+        fail_msg: |
+          tmp_path_root={{ tmp_path_root }}
+          tmp_path2={{ tmp_path2 }}
 
     #
     # readonly homedir
@@ -157,7 +167,8 @@
         that:
         - out.module_path.startswith(good_temp_path2)
         - out.module_tmpdir.startswith(good_temp_path2)
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - make_tmp_path
     - mitogen_only

--- a/tests/ansible/integration/action/remote_expand_user.yml
+++ b/tests/ansible/integration/action/remote_expand_user.yml
@@ -26,7 +26,8 @@
       register: out
     - assert:
         that: out.result == user_facts.ansible_facts.ansible_user_dir ~ '/foo'
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - name: "Expand ~/foo with become active. ~ is become_user's home."
       action_passthrough:
@@ -49,7 +50,8 @@
       register: out
     - assert:
         that: out.result == user_facts.ansible_facts.ansible_user_dir ~ '/foo'
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - name: "Expanding $HOME/foo has no effect."
       action_passthrough:
@@ -60,7 +62,8 @@
       register: out
     - assert:
         that: out.result == '$HOME/foo'
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     # ------------------------
 
@@ -73,7 +76,8 @@
       register: out
     - assert:
         that: out.result == user_facts.ansible_facts.ansible_user_dir ~ '/foo'
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - name: "sudoable; Expand ~/foo with become active. ~ is become_user's home."
       action_passthrough:
@@ -97,7 +101,8 @@
       register: out
     - assert:
         that: out.result == user_facts.ansible_facts.ansible_user_dir ~ '/foo'
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - name: "sudoable; Expanding $HOME/foo has no effect."
       action_passthrough:
@@ -108,6 +113,7 @@
       register: out
     - assert:
         that: out.result == '$HOME/foo'
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - remote_expand_user

--- a/tests/ansible/integration/action/remote_file_exists.yml
+++ b/tests/ansible/integration/action/remote_file_exists.yml
@@ -12,7 +12,8 @@
       register: out
     - assert:
         that: out.result == False
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - name: Ensure does-exist does
       copy:
@@ -24,7 +25,8 @@
       register: out
     - assert:
         that: out.result == True
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - name: Cleanup
       file:

--- a/tests/ansible/integration/action/remove_tmp_path.yml
+++ b/tests/ansible/integration/action/remove_tmp_path.yml
@@ -23,7 +23,8 @@
     - assert:
         that:
         - not out2.stat.exists
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - stat:
         path: "{{out.src|dirname}}"
@@ -32,7 +33,8 @@
     - assert:
         that:
         - not out2.stat.exists
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - file:
         path: /tmp/remove_tmp_path_test

--- a/tests/ansible/integration/action/synchronize.yml
+++ b/tests/ansible/integration/action/synchronize.yml
@@ -66,7 +66,8 @@
 
         - assert:
             that: outout == "item!"
-            fail_msg: outout={{outout}}
+            fail_msg: |
+              outout={{ outout }}
       when: False
 
     # TODO: https://github.com/dw/mitogen/issues/692

--- a/tests/ansible/integration/action/transfer_data.yml
+++ b/tests/ansible/integration/action/transfer_data.yml
@@ -22,7 +22,8 @@
     - assert:
         that: |
           out.content|b64decode == '{"I am JSON": true}'
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - name: Create text transfer data
       action_passthrough:
@@ -37,7 +38,8 @@
     - assert:
         that:
           out.content|b64decode == 'I am text.'
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - name: Cleanup transfer data
       file:

--- a/tests/ansible/integration/async/multiple_items_loop.yml
+++ b/tests/ansible/integration/async/multiple_items_loop.yml
@@ -33,6 +33,7 @@
       - out.results[1].stdout == 'hi-from-job-2'
       - out.results[1].rc == 0
       - out.results[1].delta > '0:00:05'
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - multiple_items_loop

--- a/tests/ansible/integration/async/result_binary_producing_json.yml
+++ b/tests/ansible/integration/async/result_binary_producing_json.yml
@@ -27,7 +27,8 @@
         (job.started == 1) and
         (job.changed == True) and
         (job.finished == 0)
-      fail_msg: job={{job}}
+      fail_msg: |
+        job={{ job }}
 
   - name: busy-poll up to 100000 times
     async_status:
@@ -52,7 +53,8 @@
         - async_out.failed == False
         - async_out.msg == "Hello, world."
         - 'async_out.stderr == "binary_producing_json: oh noes\n"'
-      fail_msg: async_out={{async_out}}
+      fail_msg: |
+        async_out={{ async_out }}
     vars:
       async_out: "{{result.content|b64decode|from_json}}"
   tags:

--- a/tests/ansible/integration/async/result_binary_producing_junk.yml
+++ b/tests/ansible/integration/async/result_binary_producing_junk.yml
@@ -38,7 +38,8 @@
         - async_out.msg.startswith("Traceback")
         - '"ValueError: No start of json char found\n" in async_out.msg'
         - 'async_out.stderr == "binary_producing_junk: oh noes\n"'
-      fail_msg: async_out={{async_out}}
+      fail_msg: |
+        async_out={{ async_out }}
     vars:
       async_out: "{{result.content|b64decode|from_json}}"
   tags:

--- a/tests/ansible/integration/async/result_shell_echo_hi.yml
+++ b/tests/ansible/integration/async/result_shell_echo_hi.yml
@@ -42,14 +42,16 @@
         - async_out.start.startswith("20")
         - async_out.stderr == "there"
         - async_out.stdout == "hi"
-      fail_msg: async_out={{async_out}}
+      fail_msg: |
+        async_out={{ async_out }}
     vars:
       async_out: "{{result.content|b64decode|from_json}}"
 
   - assert:
       that:
         - async_out.invocation.module_args.stdin == None
-      fail_msg: async_out={{async_out}}
+      fail_msg: |
+        async_out={{ async_out }}
     when:
       - ansible_version.full is version('2.4', '>=', strict=True)
     vars:

--- a/tests/ansible/integration/async/runner_new_process.yml
+++ b/tests/ansible/integration/async/runner_new_process.yml
@@ -15,7 +15,9 @@
   - assert:
       that:
       - sync_proc1.pid == sync_proc2.pid
-      fail_msg: sync_proc1={{sync_proc1}} sync_proc2={{sync_proc2}}
+      fail_msg: |
+        sync_proc1={{ sync_proc1 }}
+        sync_proc2={{ sync_proc2 }}
     when: is_mitogen
 
   - name: get async process ID.
@@ -52,7 +54,9 @@
       - sync_proc1.pid == sync_proc2.pid
       - async_result1.pid != sync_proc1.pid
       - async_result1.pid != async_result2.pid
-      fail_msg: async_result1={{async_result1}} async_result2={{async_result2}}
+      fail_msg: |
+        async_result1={{ async_result1 }}
+        async_result2={{ async_result2 }}
     when: is_mitogen
   tags:
     - runner_new_process

--- a/tests/ansible/integration/async/runner_one_job.yml
+++ b/tests/ansible/integration/async/runner_one_job.yml
@@ -23,7 +23,8 @@
         (job1.started == 1) and
         (job1.changed == True) and
         (job1.finished == 0)
-      fail_msg: job1={{job1}}
+      fail_msg: |
+        job1={{ job1 }}
 
   - name: busy-poll up to 100000 times
     async_status:
@@ -48,7 +49,8 @@
       - result1.start|length == 26
       - result1.finished == 1
       - result1.rc == 0
-      fail_msg: result1={{result1}}
+      fail_msg: |
+        result1={{ result1 }}
 
   - assert:
       that:
@@ -56,14 +58,16 @@
       - result1.stderr_lines == []
       - result1.stdout == "alldone"
       - result1.stdout_lines == ["alldone"]
-      fail_msg: result1={{result1}}
+      fail_msg: |
+        result1={{ result1 }}
     when:
       - ansible_version.full is version('2.8', '>', strict=True)  # ansible#51393
 
   - assert:
       that:
       - result1.failed == False
-      fail_msg: result1={{result1}}
+      fail_msg: |
+        result1={{ result1 }}
     when:
       - ansible_version.full is version('2.4', '>', strict=True)
   tags:

--- a/tests/ansible/integration/async/runner_timeout_then_polling.yml
+++ b/tests/ansible/integration/async/runner_timeout_then_polling.yml
@@ -29,7 +29,8 @@
         - result.failed == 1
         - result.finished == 1
         - result.msg == "Job reached maximum time limit of 1 seconds."
-      fail_msg: result={{result}}
+      fail_msg: |
+        result={{ result }}
   tags:
     - mitogen_only
     - runner_timeout_then_polling

--- a/tests/ansible/integration/async/runner_two_simultaneous_jobs.yml
+++ b/tests/ansible/integration/async/runner_two_simultaneous_jobs.yml
@@ -56,12 +56,15 @@
       that:
         - result1.rc == 0
         - result2.rc == 0
-      fail_msg: result1={{result1}} result2={{result2}}
+      fail_msg: |
+        result1={{ result1 }}
+        result2={{ result2 }}
 
   - assert:
       that:
         - result2.stdout == 'im_alive'
-      fail_msg: result2={{result2}}
+      fail_msg: |
+        result2={{ result2 }}
     when:
       - ansible_version.full is version('2.8', '>=', strict=True)  # ansible#51393
   tags:

--- a/tests/ansible/integration/async/runner_with_polling_and_timeout.yml
+++ b/tests/ansible/integration/async/runner_with_polling_and_timeout.yml
@@ -21,6 +21,7 @@
           job1.msg == "async task did not complete within the requested time" or
           job1.msg == "async task did not complete within the requested time - 1s" or
           job1.msg == "Job reached maximum time limit of 1 seconds."
-      fail_msg: job1={{job1}}
+      fail_msg: |
+        job1={{ job1 }}
   tags:
     - runner_with_polling_and_timeout

--- a/tests/ansible/integration/become/su_password.yml
+++ b/tests/ansible/integration/become/su_password.yml
@@ -20,7 +20,8 @@
             ('password is required' in out.msg) or
             ('password is required' in out.module_stderr)
           )
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
       when: is_mitogen
 
 
@@ -40,7 +41,8 @@
             ('Incorrect su password' in out.msg) or
             ('su password is incorrect' in out.msg)
           )
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
       when: is_mitogen
 
     - name: Ensure password su with chdir succeeds
@@ -62,7 +64,8 @@
     - assert:
         that:
           - out.stdout == 'mitogen__user1'
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
       when:
         # CI containers lack `setfacl` for unpriv -> unpriv
         # https://github.com/mitogen-hq/mitogen/issues/1118
@@ -87,7 +90,8 @@
     - assert:
         that:
           - out.stdout == 'mitogen__user1'
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
       when:
         # CI containers lack `setfacl` for unpriv -> unpriv
         # https://github.com/mitogen-hq/mitogen/issues/1118

--- a/tests/ansible/integration/become/sudo_flags_failure.yml
+++ b/tests/ansible/integration/become/sudo_flags_failure.yml
@@ -20,7 +20,8 @@
             or out.module_stderr is match("sudo: invalid option -- '-'")
             or out.module_stdout is match("sudo: unrecognized option [`']--derps'")
             or out.module_stderr is match("sudo: unrecognized option [`']--derps'")
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - sudo
     - sudo_flags_failure

--- a/tests/ansible/integration/become/sudo_nonexistent.yml
+++ b/tests/ansible/integration/become/sudo_nonexistent.yml
@@ -23,7 +23,8 @@
           - >-
             (out.module_stderr | default(out.module_stdout, true) | default(out.msg, true)) is search('sudo: unknown user:? slartibartfast')
             or (ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_version == '6.10')
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
       when:
         # https://github.com/ansible/ansible/pull/70785
         - ansible_facts.distribution not in ["MacOSX"]

--- a/tests/ansible/integration/become/sudo_nopassword.yml
+++ b/tests/ansible/integration/become/sudo_nopassword.yml
@@ -11,7 +11,8 @@
     - assert:
         that:
           - out.stdout != 'root'
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - name: Ensure passwordless sudo to root succeeds.
       shell: whoami
@@ -22,7 +23,8 @@
     - assert:
         that:
           - out.stdout == 'root'
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - sudo
     - sudo_nopassword

--- a/tests/ansible/integration/become/sudo_password.yml
+++ b/tests/ansible/integration/become/sudo_password.yml
@@ -23,7 +23,8 @@
             ('Missing sudo password' in out.msg) or
             ('password is required' in out.module_stderr)
           )
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
       when:
         # https://github.com/ansible/ansible/pull/70785
         - ansible_facts.distribution not in ["MacOSX"]
@@ -50,7 +51,8 @@
             ('Incorrect sudo password' in out.msg) or
             ('sudo password is incorrect' in out.msg)
           )
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
       when:
         # https://github.com/ansible/ansible/pull/70785
         - ansible_facts.distribution not in ["MacOSX"]

--- a/tests/ansible/integration/connection/_put_file.yml
+++ b/tests/ansible/integration/connection/_put_file.yml
@@ -26,4 +26,6 @@
     - original.stat.checksum == copied.stat.checksum
     # Upstream does not preserve timestamps at al.
     #- (not is_mitogen) or (original.stat.mtime|int == copied.stat.mtime|int)
-    fail_msg: original={{original}} copied={{copied}}
+    fail_msg: |
+      original={{ original }}
+      copied={{ copied }}

--- a/tests/ansible/integration/connection/become_same_user.yml
+++ b/tests/ansible/integration/connection/become_same_user.yml
@@ -18,7 +18,8 @@
       - out.result[0].method == "ssh"
       - out.result[0].kwargs.username == "joe"
       - out.result|length == 1  # no sudo
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
 
 
   # Now try with a different account.
@@ -34,7 +35,8 @@
       - out.result[1].method == "sudo"
       - out.result[1].kwargs.username == "james"
       - out.result|length == 2  # no sudo
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - become_same_user
     - mitogen_only

--- a/tests/ansible/integration/connection/disconnect_during_module.yml
+++ b/tests/ansible/integration/connection/disconnect_during_module.yml
@@ -29,7 +29,8 @@
       that:
       - out.rc == 4
       - "'Mitogen was disconnected from the remote environment while a call was in-progress.' in out.stdout"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - disconnect
     - disconnect_during_module

--- a/tests/ansible/integration/connection/exec_command.yml
+++ b/tests/ansible/integration/connection/exec_command.yml
@@ -16,6 +16,7 @@
       - out.result[0] == 0
       - out.result[1].decode() == "hello, world\r\n"
       - out.result[2].decode().startswith("Shared connection to ")
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - exec_command

--- a/tests/ansible/integration/connection/reset.yml
+++ b/tests/ansible/integration/connection/reset.yml
@@ -44,7 +44,11 @@
 
         # sudo PID has changed.
         - out_become.ppid != out_become2.ppid
-        fail_msg: out={{out}} out2={{out2}} out_become={{out_become}} out_become2={{out_become2}}
+        fail_msg: |
+          out={{ out }}
+          out2={{ out2 }}
+          out_become={{ out_become }}
+          out_become2={{ out_become2 }}
   tags:
     - mitogen_only
     - reset

--- a/tests/ansible/integration/connection/reset_become.yml
+++ b/tests/ansible/integration/connection/reset_become.yml
@@ -27,7 +27,9 @@
     assert:
       that:
       - become_acct.pid != login_acct.pid
-      fail_msg: become_acct={{become_acct}} login_acct={{login_acct}}
+      fail_msg: |
+        become_acct={{ become_acct }}
+        login_acct={{ login_acct }}
 
   - name: reset the connection
     meta: reset_connection
@@ -40,7 +42,9 @@
     assert:
       that:
       - become_acct.pid != new_become_acct.pid
-      fail_msg: become_acct={{become_acct}} new_become_acct={{new_become_acct}}
+      fail_msg: |
+        become_acct={{ become_acct }}
+        new_become_acct={{ new_become_acct }}
 
   - name: save new pid of login acct
     become: false
@@ -51,6 +55,8 @@
     assert:
       that:
       - login_acct.pid != new_login_acct.pid
-      fail_msg: login_acct={{login_acct}} new_login_acct={{new_login_acct}}
+      fail_msg: |
+        login_acct={{ login_acct }}
+        new_login_acct={{ new_login_acct }}
   tags:
     - reset_become

--- a/tests/ansible/integration/connection_loader/local_blemished.yml
+++ b/tests/ansible/integration/connection_loader/local_blemished.yml
@@ -11,7 +11,8 @@
 
     - assert:
         that: (not not out.mitogen_loaded) == (not not is_mitogen)
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - local
     - local_blemished

--- a/tests/ansible/integration/connection_loader/paramiko_unblemished.yml
+++ b/tests/ansible/integration/connection_loader/paramiko_unblemished.yml
@@ -14,7 +14,8 @@
 
         - assert:
             that: not out.mitogen_loaded
-            fail_msg: out={{out}}
+            fail_msg: |
+              out={{ out }}
       when: False
   tags:
     - paramiko

--- a/tests/ansible/integration/connection_loader/ssh_blemished.yml
+++ b/tests/ansible/integration/connection_loader/ssh_blemished.yml
@@ -11,7 +11,8 @@
 
     - assert:
         that: (not not out.mitogen_loaded) == (not not is_mitogen)
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - ssh
     - ssh_blemished

--- a/tests/ansible/integration/context_service/reconnection.yml
+++ b/tests/ansible/integration/context_service/reconnection.yml
@@ -31,6 +31,8 @@
     - assert:
         that:
           - old_become_env.pid != new_become_env.pid
-        fail_msg: old_become_env={{old_become_env}} new_become_env={{new_become_env}}
+        fail_msg: |
+          old_become_env={{ old_become_env }}
+          new_become_env={{ new_become_env }}
   tags:
     - reconnection

--- a/tests/ansible/integration/context_service/remote_name.yml
+++ b/tests/ansible/integration/context_service/remote_name.yml
@@ -17,7 +17,8 @@
   - assert:
       that:
       - out.stdout is match('.*python([0-9.]+)?\(mitogen:[a-z]+@[^:]+:[0-9]+\)')
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
 
   - name: Get cmdline, with mitogen_mask_remote_name
     shell: 'cat /proc/$PPID/cmdline | tr \\0 \\n'
@@ -29,7 +30,8 @@
   - assert:
       that:
       - out.stdout is match('.*python([0-9.]+)?\(mitogen:ansible\)')
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
     - remote_name

--- a/tests/ansible/integration/glibc_caches/resolv_conf.yml
+++ b/tests/ansible/integration/glibc_caches/resolv_conf.yml
@@ -46,7 +46,8 @@
         - out.failed
         - '"Name or service not known" in out.msg or
            "Temporary failure in name resolution" in out.msg'
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
       when:
         - ansible_facts.virtualization_type == "docker"
         - ansible_facts.python.version_info[:2] >= [2, 5]

--- a/tests/ansible/integration/interpreter_discovery/ansible_2_8_tests.yml
+++ b/tests/ansible/integration/interpreter_discovery/ansible_2_8_tests.yml
@@ -135,7 +135,8 @@
             assert:
               that:
               - legacy.deprecations | default([]) | length > 0
-              fail_msg: legacy={{legacy}}
+              fail_msg: |
+                legacy={{ legacy }}
             # only check for a dep warning if legacy returned /usr/bin/python and auto didn't
             when:
               - legacy.ansible_facts.discovered_interpreter_python == '/usr/bin/python'
@@ -146,7 +147,8 @@
             assert:
               that:
               - legacy.warnings | default([]) | length > 0
-              fail_msg: legacy={{legacy}}
+              fail_msg: |
+                legacy={{ legacy }}
             # only check for a warning if legacy returned /usr/bin/python and auto didn't
             when:
               - legacy.ansible_facts.discovered_interpreter_python == '/usr/bin/python'
@@ -168,7 +170,8 @@
               that:
               - auto_silent_out.warnings is not defined
               - auto_silent_out.ansible_facts.discovered_interpreter_python == auto_out.ansible_facts.discovered_interpreter_python
-              fail_msg: auto_silent_out={{auto_silent_out}}
+              fail_msg: |
+                auto_silent_out={{ auto_silent_out }}
 
 
         - name: test that auto_legacy_silent never warns and got the same answer as auto_legacy
@@ -186,7 +189,8 @@
               that:
                 - legacy_silent.warnings is not defined
                 - legacy_silent.ansible_facts.discovered_interpreter_python == legacy.ansible_facts.discovered_interpreter_python
-              fail_msg: legacy_silent={{legacy_silent}}
+              fail_msg: |
+                legacy_silent={{ legacy_silent }}
 
         - name: ensure modules can't set discovered_interpreter_X or ansible_X_interpreter
           block:
@@ -212,7 +216,7 @@
             assert:
               that:
                 - auto_out.ansible_facts.discovered_interpreter_python == discovered_interpreter_expected
-              fail_msg: >-
+              fail_msg: |
                 distro={{ distro }}
                 distro_major= {{ distro_major }}
                 system={{ system }}

--- a/tests/ansible/integration/local/cwd_preserved.yml
+++ b/tests/ansible/integration/local/cwd_preserved.yml
@@ -19,6 +19,7 @@
 
   - assert:
       that: stat.stat.exists
-      fail_msg: stat={{stat}}
+      fail_msg: |
+        stat={{ stat }}
   tags:
     - cwd_prseserved

--- a/tests/ansible/integration/module_utils/adjacent_to_playbook.yml
+++ b/tests/ansible/integration/module_utils/adjacent_to_playbook.yml
@@ -12,6 +12,7 @@
       that:
       - out.external1_path == "ansible/integration/module_utils/module_utils/external1.py"
       - out.external2_path == "ansible/lib/module_utils/external2.py"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - adjacent_to_playbook

--- a/tests/ansible/integration/module_utils/from_config_path.yml
+++ b/tests/ansible/integration/module_utils/from_config_path.yml
@@ -11,6 +11,7 @@
       that:
       - out.external1_path == "ansible/lib/module_utils/external1.py"
       - out.external2_path == "ansible/lib/module_utils/external2.py"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - from_config_path

--- a/tests/ansible/integration/module_utils/from_config_path_pkg.yml
+++ b/tests/ansible/integration/module_utils/from_config_path_pkg.yml
@@ -10,6 +10,7 @@
   - assert:
       that:
       - out.extmod_path == "ansible/lib/module_utils/externalpkg/extmod.py"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - from_config_path

--- a/tests/ansible/integration/module_utils/roles/modrole/tasks/main.yml
+++ b/tests/ansible/integration/module_utils/roles/modrole/tasks/main.yml
@@ -7,4 +7,5 @@
     that:
     - out.external3_path == "integration/module_utils/roles/modrole/module_utils/external3.py"
     - out.external2_path == "integration/module_utils/roles/modrole/module_utils/external2.py"
-    fail_msg: out={{out}}
+    fail_msg: |
+      out={{ out }}

--- a/tests/ansible/integration/module_utils/roles/overrides_modrole/tasks/main.yml
+++ b/tests/ansible/integration/module_utils/roles/overrides_modrole/tasks/main.yml
@@ -6,4 +6,5 @@
 - assert:
     that:
     - out.path == "ansible/integration/module_utils/roles/override_modrole/module_utils/known_hosts.py"
-    fail_msg: out={{out}}
+    fail_msg: |
+      out={{ out }}

--- a/tests/ansible/integration/playbook_semantics/become_flags.yml
+++ b/tests/ansible/integration/playbook_semantics/become_flags.yml
@@ -13,7 +13,8 @@
 
     - assert:
         that: "out.stdout == ''"
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - become_flags
 
@@ -29,6 +30,7 @@
 
     - assert:
         that: "out2.stdout == '2'"
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - become_flags

--- a/tests/ansible/integration/playbook_semantics/environment.yml
+++ b/tests/ansible/integration/playbook_semantics/environment.yml
@@ -11,6 +11,7 @@
 
     - assert:
         that: "result.stdout == '123'"
-        fail_msg: result={{result}}
+        fail_msg: |
+          result={{ result }}
   tags:
     - environment

--- a/tests/ansible/integration/runner/_etc_environment_global.yml
+++ b/tests/ansible/integration/runner/_etc_environment_global.yml
@@ -12,7 +12,8 @@
 
 - assert:
     that: echo.stdout == ""
-    fail_msg: echo={{echo}}
+    fail_msg: |
+      echo={{ echo }}
 
 - name: Create /etc/environment
   copy:
@@ -32,7 +33,8 @@
 
 - assert:
     that: echo.stdout == "555"
-    fail_msg: echo={{echo}}
+    fail_msg: |
+      echo={{ echo }}
 
 - name: Cleanup /etc/environment
   file:
@@ -51,4 +53,5 @@
 
 - assert:
     that: echo.stdout == ""
-    fail_msg: echo={{echo}}
+    fail_msg: |
+      echo={{ echo }}

--- a/tests/ansible/integration/runner/_etc_environment_user.yml
+++ b/tests/ansible/integration/runner/_etc_environment_user.yml
@@ -10,7 +10,8 @@
 
 - assert:
     that: echo.stdout == ""
-    fail_msg: echo={{echo}}
+    fail_msg: |
+      echo={{ echo }}
 
 - name: Copy pam_environment
   copy:
@@ -23,7 +24,8 @@
 
 - assert:
     that: echo.stdout == "321"
-    fail_msg: echo={{echo}}
+    fail_msg: |
+      echo={{ echo }}
 
 - name: Cleanup pam_environment
   file:
@@ -35,4 +37,5 @@
 
 - assert:
     that: echo.stdout == ""
-    fail_msg: echo={{echo}}
+    fail_msg: |
+      echo={{ echo }}

--- a/tests/ansible/integration/runner/atexit.yml
+++ b/tests/ansible/integration/runner/atexit.yml
@@ -25,6 +25,7 @@
     - assert:
         that:
         - not out.stat.exists
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - atexit

--- a/tests/ansible/integration/runner/builtin_command_module.yml
+++ b/tests/ansible/integration/runner/builtin_command_module.yml
@@ -16,6 +16,7 @@
           out.results[0].item == '1' and
           out.results[0].rc == 0 and
           (out.results[0].stdout == ansible_nodename)
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - builtin_command_module

--- a/tests/ansible/integration/runner/crashy_new_style_module.yml
+++ b/tests/ansible/integration/runner/crashy_new_style_module.yml
@@ -22,6 +22,7 @@
         - (out.module_stdout == "" and out.module_stderr is search(tb_pattern))
           or
           (out.module_stdout is search(tb_pattern) and out.module_stderr is match("Shared connection to localhost closed."))
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - crashy_new_style_module

--- a/tests/ansible/integration/runner/custom_bash_hashbang_argument.yml
+++ b/tests/ansible/integration/runner/custom_bash_hashbang_argument.yml
@@ -22,6 +22,7 @@
           (not out.results[0].changed) and
           out.results[0].msg == 'Here is my input' and
           out.results[0].run_via_env == "yes"
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - custom_bash_hashbang_argument

--- a/tests/ansible/integration/runner/custom_bash_old_style_module.yml
+++ b/tests/ansible/integration/runner/custom_bash_old_style_module.yml
@@ -12,6 +12,7 @@
           (not out.changed) and
           (not out.results[0].changed) and
           out.results[0].msg == 'Here is my input'
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - custom_bash_old_style_module

--- a/tests/ansible/integration/runner/custom_bash_want_json_module.yml
+++ b/tests/ansible/integration/runner/custom_bash_want_json_module.yml
@@ -11,6 +11,7 @@
           (not out.changed) and
           (not out.results[0].changed) and
           out.results[0].msg == 'Here is my input'
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - custom_bash_want_json_module

--- a/tests/ansible/integration/runner/custom_binary_producing_json.yml
+++ b/tests/ansible/integration/runner/custom_binary_producing_json.yml
@@ -23,6 +23,7 @@
           out.changed and
           out.results[0].changed and
           out.results[0].msg == 'Hello, world.'
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - custom_binary_producing_json

--- a/tests/ansible/integration/runner/custom_binary_producing_junk.yml
+++ b/tests/ansible/integration/runner/custom_binary_producing_junk.yml
@@ -31,6 +31,7 @@
         - out.results[0].failed
         - out.results[0].msg.startswith('MODULE FAILURE')
         - out.results[0].rc == 0
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - custom_binary_producing_junk

--- a/tests/ansible/integration/runner/custom_binary_single_null.yml
+++ b/tests/ansible/integration/runner/custom_binary_single_null.yml
@@ -28,7 +28,8 @@
           'custom_binary_single_null: cannot execute binary file: Exec format error\r\n',
         ))
         or (ansible_facts.distribution == 'Ubuntu' and ansible_facts.distribution_version == '16.04')
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - custom_binary_single_null
 

--- a/tests/ansible/integration/runner/custom_perl_json_args_module.yml
+++ b/tests/ansible/integration/runner/custom_perl_json_args_module.yml
@@ -10,13 +10,15 @@
         that:
         - out.results[0].input.foo
         - out.results[0].message == 'I am a perl script! Here is my input.'
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - assert:
         that:
         - (not out.changed)
         - (not out.results[0].changed)
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
       when:
         - ansible_version.full is version('2.4', '>=', strict=True)
   tags:

--- a/tests/ansible/integration/runner/custom_perl_want_json_module.yml
+++ b/tests/ansible/integration/runner/custom_perl_want_json_module.yml
@@ -10,13 +10,15 @@
         that:
         - out.results[0].input.foo
         - out.results[0].message == 'I am a want JSON perl script! Here is my input.'
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - assert:
         that:
         - (not out.changed)
         - (not out.results[0].changed)
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
       when:
         - ansible_version.full is version('2.4', '>=', strict=True)
   tags:

--- a/tests/ansible/integration/runner/custom_python_json_args_module.yml
+++ b/tests/ansible/integration/runner/custom_python_json_args_module.yml
@@ -12,6 +12,7 @@
           (not out.results[0].changed) and
           out.results[0].input[0].foo and
           out.results[0].msg == 'Here is my input'
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - custom_python_json_args_module

--- a/tests/ansible/integration/runner/custom_python_new_style_missing_interpreter.yml
+++ b/tests/ansible/integration/runner/custom_python_new_style_missing_interpreter.yml
@@ -18,7 +18,8 @@
         # Random breaking interface change since 2.7.x
         #- "out.results[0].input[0].ANSIBLE_MODULE_ARGS.foo"
         - "out.results[0].msg == 'Here is my input'"
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - custom_python_new_style_module
     - mitogen_only

--- a/tests/ansible/integration/runner/custom_python_new_style_module.yml
+++ b/tests/ansible/integration/runner/custom_python_new_style_module.yml
@@ -17,7 +17,8 @@
         # Random breaking interface change since 2.7.x
         #- "out.results[0].input[0].ANSIBLE_MODULE_ARGS.foo"
         - "out.results[0].msg == 'Here is my input'"
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     # Verify sys.argv is not Unicode.
     - custom_python_detect_environment:
@@ -26,7 +27,8 @@
     - assert:
         that:
           - out.argv_types_correct
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - custom_python_new_style_module
     - mitogen_only

--- a/tests/ansible/integration/runner/custom_python_prehistoric_module.yml
+++ b/tests/ansible/integration/runner/custom_python_prehistoric_module.yml
@@ -14,7 +14,8 @@
 
     - assert:
         that: out.ok
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - custom_python_prehistoric_module
     - mitogen_only

--- a/tests/ansible/integration/runner/custom_python_want_json_module.yml
+++ b/tests/ansible/integration/runner/custom_python_want_json_module.yml
@@ -12,6 +12,7 @@
           (not out.results[0].changed) and
           out.results[0].input[0].foo and
           out.results[0].msg == 'Here is my input'
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - custom_python_want_json_module

--- a/tests/ansible/integration/runner/custom_script_interpreter.yml
+++ b/tests/ansible/integration/runner/custom_script_interpreter.yml
@@ -14,6 +14,7 @@
           (not out.changed) and
           (not out.results[0].changed) and
           out.results[0].msg == 'Here is my input'
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - custom_script_interpreter

--- a/tests/ansible/integration/runner/environment_isolation.yml
+++ b/tests/ansible/integration/runner/environment_isolation.yml
@@ -9,7 +9,8 @@
       register: out
     - assert:
         that: not out.env.evil_key is defined
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
     - name: Verify custom env setting is cleared, with evil_key
       shell: echo 'hi'
       environment:
@@ -19,14 +20,16 @@
       register: out
     - assert:
         that: not out.env.evil_key is defined
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - name: Verify non-explicit module env mutations are cleared, control
       custom_python_detect_environment:
       register: out
     - assert:
         that: not out.env.evil_key is defined
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
     - name: Verify non-explicit module env mutations are cleared, mutate evil_key
       custom_python_modify_environ:
         key: evil_key
@@ -36,6 +39,7 @@
       register: out
     - assert:
         that: not out.env.evil_key is defined
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - environment_isolation

--- a/tests/ansible/integration/runner/forking_active.yml
+++ b/tests/ansible/integration/runner/forking_active.yml
@@ -25,7 +25,10 @@
       that:
       - fork_proc1.pid != sync_proc1.pid
       - fork_proc1.pid != fork_proc2.pid
-      fail_msg: fork_proc1={{fork_proc1}} sync_proc1={{sync_proc1}} fork_proc2={{fork_proc2}}
+      fail_msg: |
+        fork_proc1={{ fork_proc1 }}
+        sync_proc1={{ sync_proc1 }}
+        fork_proc2={{ fork_proc2 }}
 
   tags:
     - forking_active

--- a/tests/ansible/integration/runner/forking_correct_parent.yml
+++ b/tests/ansible/integration/runner/forking_correct_parent.yml
@@ -29,17 +29,23 @@
   - assert:
       that:
       - fork_proc.pid != regular_proc.pid
-      fail_msg: fork_proc={{fork_proc}} regular_proc={{regular_proc}}
+      fail_msg: |
+        fork_proc={{ fork_proc }}
+        regular_proc={{ regular_proc }}
 
   - assert:
       that: fork_proc.ppid != regular_proc.pid
-      fail_msg: fork_proc={{fork_proc}} regular_proc={{regular_proc}}
+      fail_msg: |
+        fork_proc={{ fork_proc }}
+        regular_proc={{ regular_proc }}
     when:
       - forkmode.uses_fork
 
   - assert:
       that: fork_proc.ppid == regular_proc.pid
-      fail_msg: fork_proc={{fork_proc}} regular_proc={{regular_proc}}
+      fail_msg: |
+        fork_proc={{ fork_proc }}
+        regular_proc={{ regular_proc }}
     when:
       - not forkmode.uses_fork
 

--- a/tests/ansible/integration/runner/forking_inactive.yml
+++ b/tests/ansible/integration/runner/forking_inactive.yml
@@ -16,7 +16,9 @@
   - assert:
       that:
       - sync_proc1.pid == sync_proc2.pid
-      fail_msg: sync_proc1={{sync_proc1}} sync_proc2={{sync_proc2}}
+      fail_msg: |
+        sync_proc1={{ sync_proc1 }}
+        sync_proc2={{ sync_proc2 }}
 
   tags:
     - forking_inactive

--- a/tests/ansible/integration/runner/missing_module.yml
+++ b/tests/ansible/integration/runner/missing_module.yml
@@ -23,7 +23,8 @@
     - assert:
         that: |
           'The module missing_module was not found in configured module paths' in out.stdout
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - local
     - missing_module

--- a/tests/ansible/integration/ssh/config.yml
+++ b/tests/ansible/integration/ssh/config.yml
@@ -16,7 +16,8 @@
           out.result[0].kwargs.identity_file == (
             lookup('env', 'HOME') + '/fakekey'
           )
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - config
     - mitogen_only

--- a/tests/ansible/integration/ssh/password.yml
+++ b/tests/ansible/integration/ssh/password.yml
@@ -31,7 +31,8 @@
     - assert:
         that:
           - ssh_no_password_result.unreachable == True
-        fail_msg: ssh_no_password_result={{ ssh_no_password_result }}
+        fail_msg: |
+          ssh_no_password_result={{ ssh_no_password_result }}
 
     - meta: reset_connection
     - name: ansible_ssh_pass should override ansible_password
@@ -63,4 +64,5 @@
     - assert:
         that:
           - ssh_wrong_password_result.unreachable == True
-        fail_msg: ssh_wrong_password_result={{ ssh_wrong_password_result }}
+        fail_msg: |
+          ssh_wrong_password_result={{ ssh_wrong_password_result }}

--- a/tests/ansible/integration/ssh/timeouts.yml
+++ b/tests/ansible/integration/ssh/timeouts.yml
@@ -40,7 +40,8 @@
           '"unreachable": true' in out.stdout
         - |
           '"msg": "Connection timed out."' in out.stdout
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - mitogen_only
     - timeouts

--- a/tests/ansible/integration/ssh/variables.yml
+++ b/tests/ansible/integration/ssh/variables.yml
@@ -57,6 +57,7 @@
     - assert:
         that:
           - out.rc == 4  # ansible.executor.task_queue_manager.TaskQueueManager.RUN_UNREACHABLE_HOSTS
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
   tags:
     - mitogen_only

--- a/tests/ansible/integration/strategy/_mixed_mitogen_vanilla.yml
+++ b/tests/ansible/integration/strategy/_mixed_mitogen_vanilla.yml
@@ -10,12 +10,14 @@
       register: out
     - assert:
         that: out.mitogen_loaded
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - determine_strategy:
     - assert:
         that: strategy == 'ansible.plugins.strategy.mitogen_linear.StrategyModule'
-        fail_msg: strategy={{strategy}}
+        fail_msg: |
+          strategy={{ strategy }}
   tags:
     - mitogen_linear
 
@@ -27,12 +29,14 @@
       register: out
     - assert:
         that: not out.mitogen_loaded
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - determine_strategy:
     - assert:
         that: strategy == 'ansible.plugins.strategy.linear.StrategyModule'
-        fail_msg: strategy={{strategy}}
+        fail_msg: |
+          strategy={{ strategy }}
   tags:
     - linear
 
@@ -44,11 +48,13 @@
       register: out
     - assert:
         that: out.mitogen_loaded
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - determine_strategy:
     - assert:
         that: strategy == 'ansible.plugins.strategy.mitogen_linear.StrategyModule'
-        fail_msg: strategy={{strategy}}
+        fail_msg: |
+          strategy={{ strategy }}
   tags:
     - mitogen_linear

--- a/tests/ansible/integration/strategy/_mixed_vanilla_mitogen.yml
+++ b/tests/ansible/integration/strategy/_mixed_vanilla_mitogen.yml
@@ -9,12 +9,14 @@
       register: out
     - assert:
         that: not out.mitogen_loaded
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - determine_strategy:
     - assert:
         that: strategy == 'ansible.plugins.strategy.linear.StrategyModule'
-        fail_msg: strategy={{strategy}}
+        fail_msg: |
+          strategy={{ strategy }}
   tags:
     - linear
 
@@ -26,12 +28,14 @@
       register: out
     - assert:
         that: out.mitogen_loaded
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - determine_strategy:
     - assert:
         that: strategy == 'ansible.plugins.strategy.mitogen_linear.StrategyModule'
-        fail_msg: strategy={{strategy}}
+        fail_msg: |
+          strategy={{ strategy }}
   tags:
     - mitogen_linear
 
@@ -43,11 +47,13 @@
       register: out
     - assert:
         that: not out.mitogen_loaded
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - determine_strategy:
     - assert:
         that: strategy == 'ansible.plugins.strategy.linear.StrategyModule'
-        fail_msg: strategy={{strategy}}
+        fail_msg: |
+          strategy={{ strategy }}
   tags:
     - linear

--- a/tests/ansible/integration/stub_connections/kubectl.yml
+++ b/tests/ansible/integration/stub_connections/kubectl.yml
@@ -18,7 +18,8 @@
   - assert:
       that:
       - out.env.THIS_IS_STUB_KUBECTL == '1'
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - kubectl
     - mitogen_only

--- a/tests/ansible/integration/stub_connections/lxc.yml
+++ b/tests/ansible/integration/stub_connections/lxc.yml
@@ -14,7 +14,8 @@
   - assert:
       that:
       - out.env.THIS_IS_STUB_LXC_ATTACH == '1'
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - lxc
     - mitogen_only

--- a/tests/ansible/integration/stub_connections/lxd.yml
+++ b/tests/ansible/integration/stub_connections/lxd.yml
@@ -14,7 +14,8 @@
   - assert:
       that:
       - out.env.THIS_IS_STUB_LXC == '1'
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - lxd
     - mitogen_only

--- a/tests/ansible/integration/stub_connections/mitogen_doas.yml
+++ b/tests/ansible/integration/stub_connections/mitogen_doas.yml
@@ -17,7 +17,8 @@
       that:
       - out.env.THIS_IS_STUB_DOAS == '1'
       - (out.env.ORIGINAL_ARGV|from_json)[1:3] == ['-u', 'someuser']
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_doas
     - mitogen_only

--- a/tests/ansible/integration/stub_connections/mitogen_sudo.yml
+++ b/tests/ansible/integration/stub_connections/mitogen_sudo.yml
@@ -15,7 +15,8 @@
 
   - assert:
       that: out.env.THIS_IS_STUB_SUDO == '1'
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
 
   - assert_equal:
       left: (out.env.ORIGINAL_ARGV|from_json)[1:9]

--- a/tests/ansible/integration/stub_connections/setns_lxc.yml
+++ b/tests/ansible/integration/stub_connections/setns_lxc.yml
@@ -32,7 +32,8 @@
 
     - assert:
         that: result.rc == 0
-        fail_msg: result={{result}}
+        fail_msg: |
+          result={{ result }}
   tags:
     - stns_lxc
     - mitogen_only

--- a/tests/ansible/integration/stub_connections/setns_lxd.yml
+++ b/tests/ansible/integration/stub_connections/setns_lxd.yml
@@ -32,7 +32,8 @@
 
     - assert:
         that: result.rc == 0
-        fail_msg: result={{result}}
+        fail_msg: |
+          result={{ result }}
   tags:
     - mitogen_only
     - sens_lxd

--- a/tests/ansible/integration/transport/kubectl.yml
+++ b/tests/ansible/integration/transport/kubectl.yml
@@ -74,7 +74,8 @@
           register: _
 
         - assert: { that: "'Python 3' in _.stdout" }
-          fail_msg: _={{_}}
+          fail_msg: |
+            _={{ _ }}
 
         - debug: var=_.stdout,_.stderr
           run_once: yes
@@ -84,7 +85,8 @@
           register: _
 
         - assert: { that: "'Python 2' in _.stderr" }
-          fail_msg: _={{_}}
+          fail_msg: |
+            _={{ _ }}
 
         - debug: var=_.stdout,_.stderr
           run_once: yes
@@ -117,7 +119,8 @@
 
         - assert:
             that: "'Python 3' in _.stdout"
-            fail_msg: _={{_}}
+            fail_msg: |
+              _={{ _ }}
 
         - debug: var=_.stdout,_.stderr
           run_once: yes
@@ -128,7 +131,8 @@
 
         - assert:
             that: "'Python 2' in _.stderr"
-            fail_msg: _={{_}}
+            fail_msg: |
+              _={{ _ }}
 
         - debug: var=_.stdout,_.stderr
           run_once: yes

--- a/tests/ansible/integration/transport_config/become.yml
+++ b/tests/ansible/integration/transport_config/become.yml
@@ -12,7 +12,8 @@
       - out.result|length == 1
       - out.result[0].method == "ssh"
       - out.result[0].kwargs.username == "ansible-cfg-remote-user"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -32,7 +33,8 @@
 
       - out.result[2].method == "ssh"
       - out.result[2].kwargs.hostname == "tc-become-unset"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -52,7 +54,8 @@
       - out.result[0].kwargs.username == "ansible-cfg-remote-user"
       - out.result[1].method == "sudo"
       - out.result[1].kwargs.username == "becomeuser"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -75,6 +78,7 @@
 
       - out.result[2].method == "sudo"
       - out.result[2].kwargs.username == "becomeuser"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only

--- a/tests/ansible/integration/transport_config/become_method.yml
+++ b/tests/ansible/integration/transport_config/become_method.yml
@@ -13,7 +13,8 @@
       - out.result|length == 2
       - out.result[0].method == "ssh"
       - out.result[1].method == "sudo"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -30,7 +31,8 @@
       - out.result[1].kwargs.username == "becomeuser"
       - out.result[2].method == "ssh"
       - out.result[2].kwargs.hostname == "tc-become-method-unset"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -48,7 +50,8 @@
       - out.result[0].method == "ssh"
       - out.result[1].method == "su"
       - out.result[1].kwargs.username == "becomeuser"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -70,7 +73,8 @@
 
       - out.result[2].method == "su"
       - out.result[2].kwargs.username == "becomeuser"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -93,6 +97,7 @@
 
       - out.result[2].method == "ssh"
       - out.result[2].kwargs.hostname == "tc-become-method-unset"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only

--- a/tests/ansible/integration/transport_config/become_pass.yml
+++ b/tests/ansible/integration/transport_config/become_pass.yml
@@ -14,7 +14,8 @@
       - out.result[0].method == "ssh"
       - out.result[1].method == "sudo"
       - out.result[1].kwargs.password == None
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -32,7 +33,8 @@
       - out.result[1].method == "ssh"
       - out.result[2].method == "sudo"
       - out.result[2].kwargs.password == None
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -52,7 +54,8 @@
       - out.result[2].method == "ssh"
       - out.result[3].method == "sudo"
       - out.result[3].kwargs.password == None
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -69,7 +72,8 @@
       - out.result[0].method == "ssh"
       - out.result[1].method == "sudo"
       - out.result[1].kwargs.password == "apassword"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -90,7 +94,8 @@
       - out.result[2].method == "ssh"
       - out.result[3].method == "sudo"
       - out.result[3].kwargs.password == "apassword"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -107,7 +112,8 @@
       - out.result[0].method == "ssh"
       - out.result[1].method == "sudo"
       - out.result[1].kwargs.password == "apass"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -128,7 +134,8 @@
       - out.result[2].method == "ssh"
       - out.result[3].method == "sudo"
       - out.result[3].kwargs.password == "apass"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -147,7 +154,8 @@
       # Ansible >= 2.9.2 prioritises ansible_become_pass.
       # https://github.com/ansible/ansible/commit/480b106d6535978ae6ecab68b40942ca4fa914a0
       - out.result[1].kwargs.password == "bpass"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -165,6 +173,7 @@
       - out.result[1].method == "sudo"
       - out.result[1].kwargs.password == "bpass"
       - out.result[2].method == "ssh"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only

--- a/tests/ansible/integration/transport_config/become_user.yml
+++ b/tests/ansible/integration/transport_config/become_user.yml
@@ -14,7 +14,8 @@
       - out.result[0].method == "ssh"
       - out.result[1].method == "sudo"
       - out.result[1].kwargs.username == "root"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -32,7 +33,8 @@
       - out.result[1].method == "ssh"
       - out.result[2].method == "sudo"
       - out.result[2].kwargs.username == "root"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -52,7 +54,8 @@
       - out.result[2].method == "ssh"
       - out.result[3].method == "sudo"
       - out.result[3].kwargs.username == "root"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -69,7 +72,8 @@
       - out.result[0].method == "ssh"
       - out.result[1].method == "sudo"
       - out.result[1].kwargs.username == "ansi-become-user"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -92,7 +96,8 @@
 
       - out.result[2].method == "sudo"
       - out.result[2].kwargs.username == "ansi-become-user"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -118,7 +123,8 @@
 
       - out.result[3].method == "sudo"
       - out.result[3].kwargs.username == "ansi-become-user"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 

--- a/tests/ansible/integration/transport_config/host_key_checking.yml
+++ b/tests/ansible/integration/transport_config/host_key_checking.yml
@@ -10,7 +10,8 @@
           - out.result | length == 1
           - out.result[0].method == "ssh"
           - out.result[0].kwargs.check_host_keys == "ignore"
-        fail_msg: out={{ out }}
+        fail_msg: |
+          out={{ out }}
   tags:
     - mitogen_only
 
@@ -27,7 +28,8 @@
           - out.result[0].kwargs.check_host_keys == "enforce"
           - out.result[1].method == "ssh"
           - out.result[1].kwargs.check_host_keys == "ignore"
-        fail_msg: out={{ out }}
+        fail_msg: |
+          out={{ out }}
   tags:
     - mitogen_only
 
@@ -41,7 +43,8 @@
           - out.result | length == 1
           - out.result[0].method == "ssh"
           - out.result[0].kwargs.check_host_keys == "enforce"
-        fail_msg: out={{ out }}
+        fail_msg: |
+          out={{ out }}
   tags:
     - mitogen_only
 
@@ -58,7 +61,8 @@
           - out.result[0].kwargs.check_host_keys == "ignore"
           - out.result[1].method == "ssh"
           - out.result[1].kwargs.check_host_keys == "enforce"
-        fail_msg: out={{ out }}
+        fail_msg: |
+          out={{ out }}
   tags:
     - mitogen_only
 
@@ -72,7 +76,8 @@
           - out.result | length == 1
           - out.result[0].method == "ssh"
           - out.result[0].kwargs.check_host_keys == "enforce"
-        fail_msg: out={{ out }}
+        fail_msg: |
+          out={{ out }}
   tags:
     - mitogen_only
 
@@ -89,6 +94,7 @@
           - out.result[0].kwargs.check_host_keys == "ignore"
           - out.result[1].method == "ssh"
           - out.result[1].kwargs.check_host_keys == "enforce"
-        fail_msg: out={{ out }}
+        fail_msg: |
+          out={{ out }}
   tags:
     - mitogen_only

--- a/tests/ansible/integration/transport_config/port.yml
+++ b/tests/ansible/integration/transport_config/port.yml
@@ -12,7 +12,8 @@
       - out.result|length == 1
       - out.result[0].method == "ssh"
       - out.result[0].kwargs.port == None
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -29,7 +30,8 @@
       - out.result[0].kwargs.port == None
       - out.result[1].method == "ssh"
       - out.result[1].kwargs.port == 4321
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -43,7 +45,8 @@
       - out.result|length == 1
       - out.result[0].method == "ssh"
       - out.result[0].kwargs.port == 4321
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -59,7 +62,8 @@
       - out.result[0].kwargs.port == 4321
       - out.result[1].method == "ssh"
       - out.result[1].kwargs.port == None
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -73,7 +77,8 @@
       - out.result|length == 1
       - out.result[0].method == "ssh"
       - out.result[0].kwargs.port == 1234
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -89,7 +94,8 @@
       - out.result[0].kwargs.port == 1234
       - out.result[1].method == "ssh"
       - out.result[1].kwargs.port == None
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -104,7 +110,8 @@
       - out.result|length == 1
       - out.result[0].method == "ssh"
       - out.result[0].kwargs.port == 1532
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only
 
@@ -120,6 +127,7 @@
       - out.result[0].kwargs.port == 1532
       - out.result[1].method == "ssh"
       - out.result[1].kwargs.port == None
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - mitogen_only

--- a/tests/ansible/regression/issue_109__target_has_old_ansible_installed.yml
+++ b/tests/ansible/regression/issue_109__target_has_old_ansible_installed.yml
@@ -25,7 +25,8 @@
         that:
           - env.cwd == ansible_user_dir
           - (not env.mitogen_loaded) or (env.python_path.count("") == 1)
-        fail_msg: env={{env}}
+        fail_msg: |
+          env={{ env }}
 
     - name: Run some new-style from ansible.module_utils... modules
       stat:

--- a/tests/ansible/regression/issue_113__duplicate_module_imports.yml
+++ b/tests/ansible/regression/issue_113__duplicate_module_imports.yml
@@ -20,7 +20,8 @@
       that:
         - out.status == -1
         - out.url == 'http://127.0.0.1:14321/post'
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - issue_113
 

--- a/tests/ansible/regression/issue_152__local_action_wrong_interpreter.yml
+++ b/tests/ansible/regression/issue_152__local_action_wrong_interpreter.yml
@@ -24,7 +24,8 @@
     - assert:
         that:
           - out.env.CUSTOM_INTERPRETER == "1"
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
 
     - name: Cleanup /tmp/issue_152_interpreter.sh
       file:

--- a/tests/ansible/regression/issue_152__virtualenv_python_fails.yml
+++ b/tests/ansible/regression/issue_152__virtualenv_python_fails.yml
@@ -35,7 +35,8 @@
       assert:
         that:
           - out.sys_executable in expected_executables
-        fail_msg: out={{out}}
+        fail_msg: |
+          out={{ out }}
       when:
         - lout.python.version.full is version('2.7', '>=', strict=True)
 

--- a/tests/ansible/regression/issue_154__module_state_leaks.yml
+++ b/tests/ansible/regression/issue_154__module_state_leaks.yml
@@ -14,7 +14,8 @@
       that:
         - out.results[item|int].leak1 == ["David"]
         - out.results[item|int].leak2 == ["David"]
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
     with_sequence: start=0 end=3
   tags:
     - issue_154

--- a/tests/ansible/regression/issue_332_ansiblemoduleerror_first_occurrence.yml
+++ b/tests/ansible/regression/issue_332_ansiblemoduleerror_first_occurrence.yml
@@ -16,6 +16,7 @@
   - assert:
       that:
         - out.msg == 'file (/usr/bin/does-not-exist) is absent, cannot continue'
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - issue_332

--- a/tests/ansible/regression/issue_590__sys_modules_crap.yml
+++ b/tests/ansible/regression/issue_590__sys_modules_crap.yml
@@ -11,6 +11,7 @@
   - assert:
       that:
       - "'id' in out.info"
-      fail_msg: out={{out}}
+      fail_msg: |
+        out={{ out }}
   tags:
     - issue_590


### PR DESCRIPTION
By switching to block style (`|`) with clip (no `-` or `+`) the failure messages don't require quoting and gain a single trailing newline. This causes Ansible to print them as block style, when using the yaml stdout callback plugin. As a result the values have one less layer of quoting and quote escaping, making them much easier to read.