### PR TITLE
CI: Add re-actors/alls-green GitHub Actions job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -324,3 +324,15 @@ jobs:
           fi
 
           "$PYTHON" -m tox -e "${{ matrix.tox_env }}"
+
+  # https://github.com/marketplace/actions/alls-green
+  check:
+    if: always()
+    needs:
+      - linux
+      - macos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,8 @@ Unreleased
   connection variable, and templated SSH connection password.
 * :gh:issue:`1136` tests: Improve Ansible fail_msg formatting.
 * :gh:issue:`1137` tests: Ignore inventory files of inactive tests & benchmarks
+* :gh:issue:`1138` CI: Add re-actors/alls-green GitHub Actions job to simplify
+  branch protections configuration.
 
 
 v0.3.11 (2024-10-30)


### PR DESCRIPTION
This will allow a single job to be required in the GitHub branch protection web UI; regardless of which jobs are added to or removed from the matrix of platform specific, Ansible specific jobs.

refs #1138