### PR TITLE
ansible_mitogen: Handle templated ansible_ssh_user.

### DIFF
--- a/ansible_mitogen/transport_config.py
+++ b/ansible_mitogen/transport_config.py
@@ -434,7 +434,7 @@ class PlayContextSpec(Spec):
         return self._play_context.remote_addr
 
     def remote_user(self):
-        return self._play_context.remote_user
+        return self._connection_option('remote_user')
 
     def become(self):
         return self._play_context.become

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,7 +23,7 @@ In Progress (unreleased)
 
 * :gh:issue:`1138` CI: Complete migration from Azure DevOps Pipelines to
   GitHub Actions
-* :gh:issue:`1116` :mod: `ansible_mitogen`: Support for templated variable
+* :gh:issue:`1116` :mod:`ansible_mitogen`: Support for templated variable
   `ansible_ssh_user`.
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,8 @@ In Progress (unreleased)
 
 * :gh:issue:`1138` CI: Complete migration from Azure DevOps Pipelines to
   GitHub Actions
+* :gh:issue:`1116` :mod: `ansible_mitogen`: Support for templated variable
+  `ansible_ssh_user`.
 
 
 v0.3.11 (2024-10-07)

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -127,6 +127,7 @@ sponsorship and outstanding future-thinking of its early adopters.
     <li>jgadling</li>
     <li>John F Wall &mdash; <em>Making Ansible Great with Massive Parallelism</em></li>
     <li><a href="https://github.com/jrosser">Jonathan Rosser</a></li>
+    <li><a href="https://github.com/jmkeyes">Joshua M. Keyes</a></li>
     <li>KennethC</li>
     <li><a href="https://github.com/lberruti">Luca Berruti</li>
     <li>Lewis Bellwood &mdash; <em>Happy to be apart of a great project.</em></li>

--- a/tests/ansible/hosts/default.hosts
+++ b/tests/ansible/hosts/default.hosts
@@ -25,11 +25,10 @@ tt-bare
 
 [tt_targets_bare:vars]
 ansible_host=localhost
-ansible_user=mitogen__has_sudo_nopw
 
 [tt_targets_inventory]
-tt-password                 ansible_password="{{ 'has_sudo_nopw_password' | trim }}"
+tt-password                 ansible_password="{{ 'has_sudo_nopw_password' | trim }}" ansible_user=mitogen__has_sudo_nopw
+tt-remote-user              ansible_password=has_sudo_nopw_password ansible_user="{{ 'mitogen__has_sudo_nopw' | trim }}"
 
 [tt_targets_inventory:vars]
 ansible_host=localhost
-ansible_user=mitogen__has_sudo_nopw

--- a/tests/ansible/integration/ssh/templated_by_play_taskvar.yml
+++ b/tests/ansible/integration/ssh/templated_by_play_taskvar.yml
@@ -3,6 +3,7 @@
   gather_facts: false
   vars:
     ansible_password: "{{ 'has_sudo_nopw_password' | trim }}"
+    ansible_user: "{{ 'mitogen__has_sudo_nopw' | trim }}"
 
   tasks:
     - meta: reset_connection

--- a/tests/ansible/templates/test-targets.j2
+++ b/tests/ansible/templates/test-targets.j2
@@ -47,12 +47,11 @@ tt-bare
 ansible_host={{ tt.hostname }}
 ansible_port={{ tt.port }}
 ansible_python_interpreter={{ tt.python_path }}
-ansible_user=mitogen__has_sudo_nopw
 
 [tt_targets_inventory]
-tt-password                 ansible_password="{{ '{{' }} 'has_sudo_nopw_password' | trim {{ '}}' }}"  ansible_port={{ tt.port }}
+tt-password                 ansible_password="{{ '{{' }} 'has_sudo_nopw_password' | trim {{ '}}' }}"  ansible_port={{ tt.port }} ansible_user=mitogen__has_sudo_nopw
+tt-remote-user              ansible_password=has_sudo_nopw_password  ansible_port={{ tt.port }} ansible_user="{{ '{{' }} 'mitogen__has_sudo_nopw' | trim {{ '}}' }}"
 
 [tt_targets_inventory:vars]
 ansible_host={{ tt.hostname }}
 ansible_python_interpreter={{ tt.python_path }}
-ansible_user=mitogen__has_sudo_nopw


### PR DESCRIPTION
This PR expands the evaluation of templates in inventory/group variables to include `ansible_ssh_user`.

Please let me know if it requires any changes. 

Fixes: #1116
