### PR TITLE
tests: Templated "remote_user" provided as Ansible playbook keyword

### DIFF
--- a/tests/ansible/integration/ssh/all.yml
+++ b/tests/ansible/integration/ssh/all.yml
@@ -3,5 +3,6 @@
 - import_playbook: password.yml
 - import_playbook: timeouts.yml
 - import_playbook: templated_by_inv.yml
+- import_playbook: templated_by_play_keyword.yml
 - import_playbook: templated_by_play_taskvar.yml
 - import_playbook: variables.yml

--- a/tests/ansible/integration/ssh/templated_by_play_keyword.yml
+++ b/tests/ansible/integration/ssh/templated_by_play_keyword.yml
@@ -1,0 +1,11 @@
+- name: integration/ssh/templated_by_play_keyword.yml
+  hosts: tt_targets_bare
+  gather_facts: false
+  remote_user: "{{ 'mitogen__has_sudo_nopw' | trim }}"
+  vars:
+    ansible_password: has_sudo_nopw_password
+    ansible_port: "{{ hostvars[groups['test-targets'][0]].ansible_port | default(22) }}"
+  tasks:
+    - meta: reset_connection
+    - name: Templated variables in play keywords
+      ping:


### PR DESCRIPTION
The password is provided as a variable because there is no corresponding keyword. I get the impression that keywords are considered a legacy mechanism, so most (new) options are only overridable by variables.

The port is proved as a variable for now, to test remote_name in isolation.

refs #1040 