### PR TITLE
tests: templated remote_user keyword with delegate_to

### DIFF
--- a/tests/ansible/integration/ssh/all.yml
+++ b/tests/ansible/integration/ssh/all.yml
@@ -5,4 +5,5 @@
 - import_playbook: templated_by_inv.yml
 - import_playbook: templated_by_play_keyword.yml
 - import_playbook: templated_by_play_taskvar.yml
+- import_playbook: templated_by_task_keyword.yml
 - import_playbook: variables.yml

--- a/tests/ansible/integration/ssh/templated_by_task_keyword.yml
+++ b/tests/ansible/integration/ssh/templated_by_task_keyword.yml
@@ -1,0 +1,24 @@
+- name: integration/ssh/templated_by_task_keyword.yml
+  hosts: tt_targets_bare
+  gather_facts: false
+  # FIXME Resetting the connection shouldn't require credentials
+  #       https://github.com/mitogen-hq/mitogen/issues/1132
+  remote_user: "{{ 'mitogen__has_sudo_nopw' | trim }}"
+  vars:
+    ansible_password: has_sudo_nopw_password
+    ansible_port: "{{ hostvars[groups['test-targets'][0]].ansible_port | default(22) }}"
+  tasks:
+    - name: Reset connection to target that will be delegate_to
+      meta: reset_connection
+
+- name: Test connection template by task keywords, with delegate_to
+  hosts: test-targets[0]
+  gather_facts: false
+  tasks:
+    - name: Templated by task keywords, with delegate_to
+      delegate_to: "{{ groups.tt_targets_bare[0] }}"
+      remote_user: "{{ 'mitogen__has_sudo_nopw' | trim }}"
+      vars:
+        ansible_password: has_sudo_nopw_password
+        ansible_port: "{{ hostvars[groups['test-targets'][0]].ansible_port | default(22) }}"
+      ping:


### PR DESCRIPTION
refs #1040