### PR TITLE
tests: Re-enable become/sudo tests, fix them on macOS runners

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,7 @@ In progress (unreleased)
 
 * :gh:issue:`905` :mod:`ansible_mitogen`: Support templated SSH command
   arguments (e.g. ``ansible_ssh_args``, ``ansible_ssh_extra_args``).
+* :gh:issue:`692` tests: Fix and re-enable several sudo tests
 
 
 v0.3.14 (2024-10-16)

--- a/tests/ansible/integration/action/make_tmp_path.yml
+++ b/tests/ansible/integration/action/make_tmp_path.yml
@@ -142,17 +142,16 @@
     # readonly homedir
     #
 
-    # TODO: https://github.com/dw/mitogen/issues/692
-    # - name: "Try writing to temp directory for the readonly_homedir user"
-    #   become: true
-    #   become_user: mitogen__readonly_homedir
-    #   custom_python_run_script:
-    #     script: |
-    #       from ansible.module_utils.basic import get_module_path
-    #       path = get_module_path() + '/foo.txt'
-    #       result['path'] = path
-    #       open(path, 'w').write("bar")
-    #   register: tmp_path
+    - name: Try writing to temp directory for the readonly_homedir user
+      become: true
+      become_user: mitogen__readonly_homedir
+      custom_python_run_script:
+        script: |
+          from ansible.module_utils.basic import get_module_path
+          path = get_module_path() + '/foo.txt'
+          result['path'] = path
+          open(path, 'w').write("bar")
+      register: tmp_path
 
     #
     # modules get the same base dir

--- a/tests/ansible/integration/action/synchronize.yml
+++ b/tests/ansible/integration/action/synchronize.yml
@@ -40,11 +40,11 @@
       delegate_to: localhost
       run_once: true
 
-    # TODO: https://github.com/dw/mitogen/issues/692
-    # - file:
-    #     path: /tmp/sync-test.out
-    #     state: absent
-    #   become: true
+    - name: Ensure clean slate
+      become: true
+      file:
+        path: /tmp/sync-test.out
+        state: absent
 
     # exception:   File "/tmp/venv/lib/python2.7/site-packages/ansible/plugins/action/__init__.py", line 129, in cleanup
     # exception:     self._remove_tmp_path(self._connection._shell.tmpdir)
@@ -70,14 +70,14 @@
               outout={{ outout }}
       when: False
 
-    # TODO: https://github.com/dw/mitogen/issues/692
-    # - file:
-    #     path: "{{item}}"
-    #     state: absent
-    #   become: true
-    #   with_items:
-    #   - /tmp/synchronize-action-key
-    #   - /tmp/sync-test
-    #   - /tmp/sync-test.out
+    - name: Cleanup
+      become: true
+      file:
+        path: "{{ item }}"
+        state: absent
+      with_items:
+        - /tmp/synchronize-action-key
+        - /tmp/sync-test
+        - /tmp/sync-test.out
   tags:
     - synchronize

--- a/tests/ansible/integration/become/sudo_password.yml
+++ b/tests/ansible/integration/become/sudo_password.yml
@@ -5,10 +5,12 @@
   tasks:
 
     - name: Ensure sudo password absent but required.
-      shell: whoami
       become: true
       become_user: mitogen__pw_required
+      command:
+        cmd: whoami
       register: out
+      changed_when: false
       ignore_errors: true
       when:
         # https://github.com/ansible/ansible/pull/70785
@@ -32,10 +34,12 @@
           or is_mitogen
 
     - name: Ensure password sudo incorrect.
-      shell: whoami
       become: true
       become_user: mitogen__pw_required
+      command:
+        cmd: whoami
       register: out
+      changed_when: false
       vars:
         ansible_become_pass: nopes
       ignore_errors: true
@@ -59,18 +63,27 @@
           or ansible_version.full is version("2.11", ">=", strict=True)
           or is_mitogen
 
-    # TODO: https://github.com/dw/mitogen/issues/692
-    # - name: Ensure password sudo succeeds.
-    #   shell: whoami
-    #   become: true
-    #   become_user: mitogen__pw_required
-    #   register: out
-    #   vars:
-    #     ansible_become_pass: pw_required_password
+    - block:
+        - name: Ensure password sudo succeeds
+          become: true
+          become_user: mitogen__pw_required
+          vars:
+            ansible_become_pass: pw_required_password
+          command:
+            cmd: whoami
+          register: sudo_password_success_whoami
+          changed_when: false
 
-    # - assert:
-    #     that:
-    #       - out.stdout == 'mitogen__pw_required'
+        - assert:
+            that:
+              - sudo_password_success_whoami.stdout == 'mitogen__pw_required'
+            fail_msg: |
+              sudo_password_success_whoami={{ sudo_password_success_whoami }}
+      when:
+        # https://github.com/ansible/ansible/pull/70785
+        - ansible_facts.distribution not in ["MacOSX"]
+          or ansible_version.full is version("2.11", ">=", strict=True)
+          or is_mitogen
   tags:
     - sudo
     - sudo_password

--- a/tests/ansible/integration/become/sudo_requiretty.yml
+++ b/tests/ansible/integration/become/sudo_requiretty.yml
@@ -3,34 +3,38 @@
 - name: integration/become/sudo_requiretty.yml
   hosts: test-targets
   tasks:
-    # - include_tasks: ../_mitogen_only.yml
+    # AIUI Vanilla Ansible cannot do sudo when requiretty configured
+    - include_tasks: ../_mitogen_only.yml
 
-    # TODO: https://github.com/dw/mitogen/issues/692
-    # - name: Verify we can login to a non-passworded requiretty account
-    #   shell: whoami
-    #   become: true
-    #   become_user: mitogen__require_tty
-    #   register: out
+    - name: Verify we can login to a non-passworded requiretty account
+      become: true
+      become_user: mitogen__require_tty
+      command:
+        cmd: whoami
+      changed_when: false
+      register: sudo_require_tty_whoami
 
-    # - assert:
-    #     that:
-    #       - out.stdout == 'mitogen__require_tty'
+    - assert:
+        that:
+          - sudo_require_tty_whoami.stdout == 'mitogen__require_tty'
+        fail_msg: |
+          sudo_require_tty_whoami={{ sudo_require_tty_whoami }}
 
+    - name: Verify we can login to a passworded requiretty account
+      become: true
+      become_user: mitogen__require_tty_pw_required
+      vars:
+        ansible_become_pass: require_tty_pw_required_password
+      command:
+        cmd: whoami
+      changed_when: false
+      register: sudo_require_tty_password_whoami
 
-    # ---------------
-
-    # TODO: https://github.com/dw/mitogen/issues/692
-    # - name: Verify we can login to a passworded requiretty account
-    #   shell: whoami
-    #   become: true
-    #   become_user: mitogen__require_tty_pw_required
-    #   vars:
-    #     ansible_become_pass: require_tty_pw_required_password
-    #   register: out
-
-    # - assert:
-    #     that:
-    #       - out.stdout == 'mitogen__require_tty_pw_required'
+    - assert:
+        that:
+          - sudo_require_tty_password_whoami.stdout == 'mitogen__require_tty_pw_required'
+        fail_msg: |
+          sudo_require_tty_password_whoami={{ sudo_require_tty_password_whoami }}
   tags:
     - mitogen_only
     - sudo

--- a/tests/ansible/integration/playbook_semantics/with_items.yml
+++ b/tests/ansible/integration/playbook_semantics/with_items.yml
@@ -3,30 +3,39 @@
 
 - name: integration/playbook_semantics/with_items.yml
   hosts: test-targets
+  gather_facts: true
   tasks:
+    - block:
+        - name: Spin up a few interpreters
+          become: true
+          vars:
+            ansible_become_user: "mitogen__user{{ item }}"
+          command:
+            cmd: whoami
+          with_sequence: start=1 end=3
+          register: first_run
+          changed_when: false
 
-    # TODO: https://github.com/dw/mitogen/issues/692
-    # - name: Spin up a few interpreters
-    #   shell: whoami
-    #   become: true
-    #   vars:
-    #     ansible_become_user: "mitogen__user{{item}}"
-    #   with_sequence: start=1 end=3
-    #   register: first_run
+        - name: Reuse them
+          become: true
+          vars:
+            ansible_become_user: "mitogen__user{{ item }}"
+          command:
+            cmd: whoami
+          with_sequence: start=1 end=3
+          register: second_run
+          changed_when: false
 
-    # - name: Reuse them
-    #   shell: whoami
-    #   become: true
-    #   vars:
-    #     ansible_become_user: "mitogen__user{{item}}"
-    #   with_sequence: start=1 end=3
-    #   register: second_run
-
-    # - name: Verify first and second run matches expected username.
-    #   assert:
-    #     that:
-    #     - first_run.results[item|int].stdout == ("mitogen__user%d" % (item|int + 1))
-    #     - first_run.results[item|int].stdout == second_run.results[item|int].stdout
-    #   with_sequence: start=0 end=2
-  tags:
-    - custom_python_new_style_module
+        - name: Verify first and second run matches expected username.
+          vars:
+            user_expected: "mitogen__user{{ item | int + 1 }}"
+          assert:
+            that:
+              - first_run.results[item | int].stdout == user_expected
+              - second_run.results[item | int].stdout == user_expected
+          with_sequence: start=0 end=2
+      when:
+        # https://github.com/ansible/ansible/pull/70785
+        - ansible_facts.distribution not in ["MacOSX"]
+          or ansible_version.full is version("2.11", ">=", strict=True)
+          or is_mitogen

--- a/tests/image_prep/_user_accounts.yml
+++ b/tests/image_prep/_user_accounts.yml
@@ -73,6 +73,7 @@
       - user:
           name: "mitogen__{{item}}"
           shell: /bin/bash
+          group: staff
           groups: |
             {{
                 ['com.apple.access_ssh'] +

--- a/tests/image_prep/ansible.cfg
+++ b/tests/image_prep/ansible.cfg
@@ -6,6 +6,7 @@ retry_files_enabled = false
 display_args_to_stdout = True
 no_target_syslog = True
 host_key_checking = False
+stdout_callback = yaml
 
 [inventory]
 unparsed_is_fatal = true


### PR DESCRIPTION
The tasks in tests/imageprep/_user_accounts.yml that create users did not specify a primary group for those users - this left the decision to Ansible's user module, and/or the underlying OS. In Ansible 9+ (ansible-core 2.16+ the user module defaults to primary group "staff." Earlier don't supply a default, which releases probably results in a primary group nameed "None" (due to stringifying the Python singleton of the same name), or whatever the macOS Directory Services has for no data/NULL.

The invalid GID 4294967295 (MAX_UINT32 == 2**32-1) in the sudo error probably enters the mix via something similar to sudo https://github.com/advisories/GHSA-33h3-qhjg-4qmf.

Fixes https://github.com/mitogen-hq/mitogen/issues/692

See
- https://github.com/ansible/ansible/pull/79999
- https://github.com/ansible/ansible/commit/c69c83c962f987c78af98da0746527df
- https://www.sudo.ws/security/advisories/minus_1_uid/

> Bruce Wayne : [confused]  Am I meant to understand any of that?
> Lucius Fox : Not at all, I just wanted you to know how hard it was.
> -- Batman Begins