### PR TITLE
ansible_mitogen: Template become command arguments (become_flags)

### DIFF
--- a/ansible_mitogen/transport_config.py
+++ b/ansible_mitogen/transport_config.py
@@ -214,6 +214,12 @@ class Spec(with_metaclass(abc.ABCMeta, object)):
         """
 
     @abc.abstractmethod
+    def become_flags(self):
+        """
+        The command line arguments passed to the become executable.
+        """
+
+    @abc.abstractmethod
     def become_method(self):
         """
         The name of the Ansible become method to use.
@@ -290,10 +296,9 @@ class Spec(with_metaclass(abc.ABCMeta, object)):
     @abc.abstractmethod
     def sudo_args(self):
         """
-        The list of additional arguments that should be included in a become
+        The list of additional arguments that should be included in a sudo
         invocation.
         """
-        # TODO: split out into sudo_args/become_args.
 
     @abc.abstractmethod
     def mitogen_via(self):
@@ -431,6 +436,7 @@ class PlayContextSpec(Spec):
 
             fallback_options = {
                 'become_exe',
+                'become_flags',
             }
             if name not in fallback_options:
                 raise
@@ -463,6 +469,9 @@ class PlayContextSpec(Spec):
 
     def become(self):
         return self._connection.become
+
+    def become_flags(self):
+        return self._become_option('become_flags')
 
     def become_method(self):
         return self._play_context.become_method
@@ -529,19 +538,7 @@ class PlayContextSpec(Spec):
         return self._become_option('become_exe')
 
     def sudo_args(self):
-        return [
-            mitogen.core.to_text(term)
-            for term in ansible.utils.shlex.shlex_split(
-                first_true((
-                    self._play_context.become_flags,
-                    # Ansible <=2.7.
-                    getattr(self._play_context, 'sudo_flags', ''),
-                    # Ansible <=2.3.
-                    getattr(C, 'DEFAULT_BECOME_FLAGS', ''),
-                    getattr(C, 'DEFAULT_SUDO_FLAGS', '')
-                ), default='')
-            )
-        ]
+        return ansible.utils.shlex.shlex_split(self.become_flags() or '')
 
     def mitogen_via(self):
         return self._connection.get_task_var('mitogen_via')
@@ -676,6 +673,9 @@ class MitogenViaSpec(Spec):
     def become(self):
         return bool(self._become_user)
 
+    def become_flags(self):
+        return self._host_vars.get('ansible_become_flags')
+
     def become_method(self):
         return (
             self._become_method or
@@ -771,7 +771,7 @@ class MitogenViaSpec(Spec):
             mitogen.core.to_text(term)
             for s in (
                 self._host_vars.get('ansible_sudo_flags') or '',
-                self._host_vars.get('ansible_become_flags') or '',
+                self.become_flags() or '',
             )
             for term in ansible.utils.shlex.shlex_split(s)
         ]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,8 @@ In progress (unreleased)
 
 * :gh:issue:`1083` :mod:`ansible_mitogen`: Templated become executable
   (e.g. ``become_exe``).
+* :gh:issue:`1083` :mod:`ansible_mitogen`: Templated become executable
+  arguments (e.g. ``become_flags``).
 
 
 v0.3.15 (2024-10-28)

--- a/tests/ansible/hosts/default.hosts
+++ b/tests/ansible/hosts/default.hosts
@@ -34,6 +34,7 @@ ansible_user="{{ lookup('pipe', 'whoami') }}"
 
 [tt_become_by_inv]
 tt-become-exe               ansible_become=true ansible_become_exe="{{ 'sudo' | trim }}" ansible_become_user=root
+tt-become-flags             ansible_become=true ansible_become_flags="{{ '--set-home --stdin --non-interactive' | trim }}" ansible_become_user=root
 tt-become-pass              ansible_become=true ansible_become_pass="{{ 'pw_required_password' | trim }}" ansible_become_user=mitogen__pw_required
 tt-become-user              ansible_become=true ansible_become_user="{{ 'root' | trim }}"
 

--- a/tests/ansible/integration/become/templated_by_inv.yml
+++ b/tests/ansible/integration/become/templated_by_inv.yml
@@ -13,6 +13,7 @@
       vars:
         expected_become_users:
           tt-become-exe: root
+          tt-become-flags: root
           tt-become-pass: mitogen__pw_required
           tt-become-user: root
       command:

--- a/tests/ansible/integration/become/templated_by_play_keywords.yml
+++ b/tests/ansible/integration/become/templated_by_play_keywords.yml
@@ -3,6 +3,7 @@
   gather_facts: false
   become: true
   become_exe: "{{ 'sudo' | trim }}"
+  become_flags: "{{ '--set-home --stdin --non-interactive' | trim }}"
   become_user: "{{ 'root' | trim }}"
   tasks:
     - meta: reset_connection
@@ -22,6 +23,7 @@
   gather_facts: false
   become: true
   become_exe: "{{ 'sudo' | trim }}"
+  become_flags: "{{ '--set-home --stdin --non-interactive' | trim }}"
   become_user: "{{ 'mitogen__pw_required' | trim }}"
   vars:
     ansible_become_pass: "{{ 'pw_required_password' | trim }}"

--- a/tests/ansible/integration/become/templated_by_play_vars.yml
+++ b/tests/ansible/integration/become/templated_by_play_vars.yml
@@ -4,6 +4,7 @@
   vars:
     ansible_become: true
     ansible_become_exe: "{{ 'sudo' | trim }}"
+    ansible_become_flags: "{{ '--set-home --stdin --non-interactive' | trim }}"
     ansible_become_user: "{{ 'root' | trim }}"
   tasks:
     - name: Templated become by play vars, no password
@@ -22,6 +23,7 @@
   vars:
     ansible_become: true
     ansible_become_exe: "{{ 'sudo' | trim }}"
+    ansible_become_flags: "{{ '--set-home --stdin --non-interactive' | trim }}"
     ansible_become_pass: "{{ 'pw_required_password' | trim }}"
     ansible_become_user: "{{ 'mitogen__pw_required' | trim }}"
   tasks:

--- a/tests/ansible/integration/become/templated_by_task_keywords.yml
+++ b/tests/ansible/integration/become/templated_by_task_keywords.yml
@@ -5,6 +5,7 @@
   #       https://github.com/mitogen-hq/mitogen/issues/1132
   become: true
   become_exe: "{{ 'sudo' | trim }}"
+  become_flags: "{{ '--set-home --stdin --non-interactive' | trim }}"
   become_user: "{{ 'root' | trim }}"
   tasks:
     - name: Reset connection to target that will be delegate_to
@@ -17,6 +18,7 @@
     - name: Templated become by task keywords, with delegate_to
       become: true
       become_exe: "{{ 'sudo' | trim }}"
+      become_flags: "{{ '--set-home --stdin --non-interactive' | trim }}"
       become_user: "{{ 'root' | trim }}"
       delegate_to: "{{ groups.tt_become_bare[0] }}"
       command:
@@ -36,6 +38,7 @@
   #       https://github.com/mitogen-hq/mitogen/issues/1132
   become: true
   become_exe: "{{ 'sudo' | trim }}"
+  become_flags: "{{ '--set-home --stdin --non-interactive' | trim }}"
   become_user: "{{ 'mitogen__pw_required' | trim }}"
   vars:
     ansible_become_pass: "{{ 'pw_required_password' | trim }}"
@@ -56,6 +59,7 @@
     - name: Templated become by task keywords, with delegate_to
       become: true
       become_exe: "{{ 'sudo' | trim }}"
+      become_flags: "{{ '--set-home --stdin --non-interactive' | trim }}"
       become_user: "{{ 'mitogen__pw_required' | trim }}"
       delegate_to: "{{ groups.tt_become_bare[0] }}"
       vars:

--- a/tests/ansible/templates/test-targets.j2
+++ b/tests/ansible/templates/test-targets.j2
@@ -59,6 +59,7 @@ ansible_user=mitogen__has_sudo_nopw
 
 [tt_become_by_inv]
 tt-become-exe               ansible_become=true ansible_become_exe="{{ '{{' }} 'sudo' | trim {{ '}}' }}" ansible_become_user=root
+tt-become-flags             ansible_become=true ansible_become_flags="{{ '{{' }} '--set-home --stdin --non-interactive' | trim {{ '}}' }}" ansible_become_user=root
 tt-become-pass              ansible_become=true ansible_become_pass="{{ '{{' }} 'pw_required_password' | trim {{ '}}' }}" ansible_become_user=mitogen__pw_required
 tt-become-user              ansible_become=true ansible_become_user="{{ '{{' }} 'root' | trim {{ '}}' }}"
 


### PR DESCRIPTION
Uses the same fallback for (mitogen_sudo et al) as become_exe (see #1173).

The new `Spec.become_flags()` is not yet explicitly tested. Note that it returns a string (matching the Ansible option of the same name), whereas `Spec.sudo_args()` returns a list.

refs #1083