### PR TITLE
ansible_mitogen: Templated ssh executable

### DIFF
--- a/ansible_mitogen/transport_config.py
+++ b/ansible_mitogen/transport_config.py
@@ -511,7 +511,7 @@ class PlayContextSpec(Spec):
         return self._play_context.private_key_file
 
     def ssh_executable(self):
-        return C.config.get_config_value("ssh_executable", plugin_type="connection", plugin_name="ssh", variables=self._task_vars.get("vars", {}))
+        return self._connection_option('ssh_executable')
 
     def timeout(self):
         return self._play_context.timeout

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,10 @@ In progress (unreleased)
   (e.g. ``become_exe``).
 * :gh:issue:`1083` :mod:`ansible_mitogen`: Templated become executable
   arguments (e.g. ``become_flags``).
+* :gh:issue:`1083` :mod:`ansible_mitogen`: Templated ssh executable
+  (``ansible_ssh_executable``).
+* :gh:issue:`1083` :mod:`ansible_mitogen`: Fixed templated connection options
+  during a ``meta: reset_connection`` task.
 
 
 v0.3.15 (2024-10-28)

--- a/tests/ansible/hosts/default.hosts
+++ b/tests/ansible/hosts/default.hosts
@@ -46,6 +46,7 @@ ansible_user="{{ lookup('pipe', 'whoami') }}"
 tt-password                 ansible_password="{{ 'has_sudo_nopw_password' | trim }}" ansible_user=mitogen__has_sudo_nopw
 tt-port                     ansible_password=has_sudo_nopw_password ansible_port="{{ 22 | int }}" ansible_user=mitogen__has_sudo_nopw
 tt-remote-user              ansible_password=has_sudo_nopw_password ansible_user="{{ 'mitogen__has_sudo_nopw' | trim }}"
+tt-ssh-executable           ansible_password=has_sudo_nopw_password ansible_ssh_executable="{{ 'ssh' | trim }}" ansible_user=mitogen__has_sudo_nopw
 
 [tt_targets_inventory:vars]
 ansible_host=localhost

--- a/tests/ansible/integration/ssh/templated_by_play_taskvar.yml
+++ b/tests/ansible/integration/ssh/templated_by_play_taskvar.yml
@@ -4,6 +4,7 @@
   vars:
     ansible_password: "{{ 'has_sudo_nopw_password' | trim }}"
     ansible_port: "{{ hostvars[groups['test-targets'][0]].ansible_port | default(22) }}"
+    ansible_ssh_executable: "{{ 'ssh' | trim }}"
     ansible_user: "{{ 'mitogen__has_sudo_nopw' | trim }}"
 
   tasks:

--- a/tests/ansible/templates/test-targets.j2
+++ b/tests/ansible/templates/test-targets.j2
@@ -74,6 +74,7 @@ ansible_user=mitogen__has_sudo_nopw
 tt-password                 ansible_password="{{ '{{' }} 'has_sudo_nopw_password' | trim {{ '}}' }}"  ansible_port={{ tt.port }} ansible_user=mitogen__has_sudo_nopw
 tt-port                     ansible_password=has_sudo_nopw_password  ansible_port="{{ '{{' }} {{ tt.port }} | int {{ '}}' }}"  ansible_user=mitogen__has_sudo_nopw
 tt-remote-user              ansible_password=has_sudo_nopw_password  ansible_port={{ tt.port }} ansible_user="{{ '{{' }} 'mitogen__has_sudo_nopw' | trim {{ '}}' }}"
+tt-ssh-executable           ansible_password=has_sudo_nopw_password  ansible_port={{ tt.port }} ansible_ssh_executable="{{ '{{' }} 'ssh' | trim {{ '}}' }}" ansible_user=mitogen__has_sudo_nopw
 
 [tt_targets_inventory:vars]
 ansible_host={{ tt.hostname }}


### PR DESCRIPTION
Adding a the tt-ssh-executable test target uncovered Ansible bug https://github.com/ansible/ansible/issues/84238 during `meta: reset_connection` tasks. So this commit includes a workaround for affected versions of Ansible.

refs #1083, 