### PR TITLE
CI: Fix incorrect u=r,g=r,o=rw file permissions on mitogen__has_sudo_pubkey.key

### DIFF
--- a/.ci/ansible_tests.py
+++ b/.ci/ansible_tests.py
@@ -41,7 +41,7 @@ with ci_lib.Fold('docker_setup'):
 
 with ci_lib.Fold('job_setup'):
     os.chdir(TESTS_DIR)
-    os.chmod('../data/docker/mitogen__has_sudo_pubkey.key', int('0600', 7))
+    os.chmod('../data/docker/mitogen__has_sudo_pubkey.key', int('0600', 8))
 
     ci_lib.run("mkdir %s", HOSTS_DIR)
     for path in glob.glob(TESTS_DIR + '/hosts/*'):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,8 @@ To avail of fixes in an unreleased version, please download a ZIP file
 In progress (unreleased)
 ------------------------
 
+* :gh:issue:`1182` CI: Fix incorrect world readable/writable file permissions
+  on SSH key ``mitogen__has_sudo_pubkey.key`` during Ansible tests.
 
 
 v0.3.16 (2024-11-05)

--- a/tests/ansible/integration/ssh/variables.yml
+++ b/tests/ansible/integration/ssh/variables.yml
@@ -13,11 +13,6 @@
       -o "ControlPath /tmp/mitogen-ansible-test-{{18446744073709551615|random}}"
 
   tasks:
-    - name: setup ansible_ssh_private_key_file
-      shell: chmod 0600 ../data/docker/mitogen__has_sudo_pubkey.key
-      args:
-        chdir: ../..
-
     - name: ansible_user, ansible_ssh_private_key_file
       shell: >
         ANSIBLE_ANY_ERRORS_FATAL=false
@@ -34,6 +29,7 @@
       args:
         chdir: ../..
       register: out
+      changed_when: false
 
     - name: ansible_user, wrong ansible_ssh_private_key_file
       shell: >
@@ -52,6 +48,7 @@
       args:
         chdir: ../..
       register: out
+      changed_when: false
       ignore_errors: true
 
     - assert:


### PR DESCRIPTION
The wrong base was used when calculating the mode. So the file became world readable and writable on a CI runner, until
ansible/integration/ssh/variables.yml happened to correct it near the end of the integration tests.

I believe this was the only instance.

```
mitogen git:(issue1182) ✗ ag --python 'int\(.+7\)' . .ci | wc -l
       0
```

fixes #1182