### PR TITLE
ansible_mitogen: Templated become flag

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,8 @@ In progress (unreleased)
 
 * :gh:issue:`1083` :mod:`ansible_mitogen`: Templated become method
   (e.g. ``ansible_become_method``).
+* :gh:issue:`1083` :mod:`ansible_mitogen`: Templated become flag
+  (e.g. ``ansible_become_method``, ``become`` keyword).
 
 
 v0.3.17 (2024-11-07)

--- a/tests/ansible/hosts/default.hosts
+++ b/tests/ansible/hosts/default.hosts
@@ -30,6 +30,7 @@ ansible_host=localhost
 ansible_user="{{ lookup('pipe', 'whoami') }}"
 
 [tt_become_by_inv]
+tt-become                   ansible_become="{{ 'true' | trim }}" ansible_become_user=root
 tt-become-exe               ansible_become=true ansible_become_exe="{{ 'sudo' | trim }}" ansible_become_user=root
 tt-become-flags             ansible_become=true ansible_become_flags="{{ '--set-home --stdin --non-interactive' | trim }}" ansible_become_user=root
 tt-become-method            ansible_become=true ansible_become_method="{{ 'sudo' | trim }}" ansible_become_user=root

--- a/tests/ansible/integration/become/templated_by_inv.yml
+++ b/tests/ansible/integration/become/templated_by_inv.yml
@@ -12,6 +12,7 @@
     - name: Templated become in inventory
       vars:
         expected_become_users:
+          tt-become: root
           tt-become-exe: root
           tt-become-flags: root
           tt-become-method: root

--- a/tests/ansible/integration/become/templated_by_play_keywords.yml
+++ b/tests/ansible/integration/become/templated_by_play_keywords.yml
@@ -1,7 +1,7 @@
 - name: integration/become/templated_by_play_keywords.yml
   hosts: tt_become_bare
   gather_facts: false
-  become: true
+  become: "{{ 'true' | trim }}"
   become_exe: "{{ 'sudo' | trim }}"
   become_flags: "{{ '--set-home --stdin --non-interactive' | trim }}"
   become_method: "{{ 'sudo' | trim }}"
@@ -22,7 +22,7 @@
 - name: integration/become/templated_by_play_keywords.yml
   hosts: tt_become_bare
   gather_facts: false
-  become: true
+  become: "{{ 'true' | trim }}"
   become_exe: "{{ 'sudo' | trim }}"
   become_flags: "{{ '--set-home --stdin --non-interactive' | trim }}"
   become_method: "{{ 'sudo' | trim }}"

--- a/tests/ansible/integration/become/templated_by_task_keywords.yml
+++ b/tests/ansible/integration/become/templated_by_task_keywords.yml
@@ -3,7 +3,7 @@
   gather_facts: false
   # FIXME Resetting the connection shouldn't require credentials
   #       https://github.com/mitogen-hq/mitogen/issues/1132
-  become: true
+  become: "{{ 'true' | trim }}"
   become_exe: "{{ 'sudo' | trim }}"
   become_flags: "{{ '--set-home --stdin --non-interactive' | trim }}"
   become_method: "{{ 'sudo' | trim }}"
@@ -17,7 +17,7 @@
   gather_facts: false
   tasks:
     - name: Templated become by task keywords, with delegate_to
-      become: true
+      become: "{{ 'true' | trim }}"
       become_exe: "{{ 'sudo' | trim }}"
       become_flags: "{{ '--set-home --stdin --non-interactive' | trim }}"
       become_method: "{{ 'sudo' | trim }}"
@@ -38,7 +38,7 @@
   gather_facts: false
   # FIXME Resetting the connection shouldn't require credentials
   #       https://github.com/mitogen-hq/mitogen/issues/1132
-  become: true
+  become: "{{ 'true' | trim }}"
   become_exe: "{{ 'sudo' | trim }}"
   become_flags: "{{ '--set-home --stdin --non-interactive' | trim }}"
   become_method: "{{ 'sudo' | trim }}"
@@ -60,7 +60,7 @@
       setup:
 
     - name: Templated become by task keywords, with delegate_to
-      become: true
+      become: "{{ 'true' | trim }}"
       become_exe: "{{ 'sudo' | trim }}"
       become_flags: "{{ '--set-home --stdin --non-interactive' | trim }}"
       become_method: "{{ 'sudo' | trim }}"

--- a/tests/ansible/templates/test-targets.j2
+++ b/tests/ansible/templates/test-targets.j2
@@ -57,6 +57,7 @@ ansible_python_interpreter={{ tt.python_path }}
 ansible_user=mitogen__has_sudo_nopw
 
 [tt_become_by_inv]
+tt-become                   ansible_become="{{ '{{' }} 'true' | trim {{ '}}' }}" ansible_become_user=root
 tt-become-exe               ansible_become=true ansible_become_exe="{{ '{{' }} 'sudo' | trim {{ '}}' }}" ansible_become_user=root
 tt-become-flags             ansible_become=true ansible_become_flags="{{ '{{' }} '--set-home --stdin --non-interactive' | trim {{ '}}' }}" ansible_become_user=root
 tt-become-method            ansible_become=true ansible_become_method="{{ '{{' }} 'sudo' | trim {{ '}}' }}" ansible_become_user=root


### PR DESCRIPTION
The code change to support this was already made in transport_config.py, as part of templated become_user support (commit bf6607e27e01, PR #1148). This commit adds tests to confirm the functionality.

refs #1083 