### PR TITLE
ansible_mitogen: Fix timeout in wait_for_connection with templated ansible_python_interpreter

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,8 @@ To avail of fixes in an unreleased version, please download a ZIP file
 In progress (unreleased)
 ------------------------
 
+* :gh:issue:`1079` :mod:`ansible_mitogen`: Fix :ans:mod:`wait_for_connection`
+  timeout with templated ``ansible_python_interpreter``
 
 
 v0.3.19 (2024-12-02)

--- a/tests/ansible/hosts/default.hosts
+++ b/tests/ansible/hosts/default.hosts
@@ -19,6 +19,9 @@ ssh-common-args ansible_host=localhost ansible_user="{{ lookup('pipe', 'whoami')
 ansible_ssh_common_args=-o PermitLocalCommand=yes -o LocalCommand="touch {{ ssh_args_canary_file }}"
 ssh_args_canary_file=/tmp/ssh_args_by_inv_{{ inventory_hostname }}
 
+[issue1079]
+wait-for-connection ansible_host=localhost ansible_user="{{ lookup('pipe', 'whoami') }}"
+
 [tt_targets_bare]
 tt-bare
 

--- a/tests/ansible/regression/all.yml
+++ b/tests/ansible/regression/all.yml
@@ -16,4 +16,5 @@
 - import_playbook: issue_776__load_plugins_called_twice.yml
 - import_playbook: issue_952__ask_become_pass.yml
 - import_playbook: issue_1066__add_host__host_key_checking.yml
+- import_playbook: issue_1079__wait_for_connection_timeout.yml
 - import_playbook: issue_1087__template_streamerror.yml

--- a/tests/ansible/regression/issue_1079__wait_for_connection_timeout.yml
+++ b/tests/ansible/regression/issue_1079__wait_for_connection_timeout.yml
@@ -1,0 +1,10 @@
+- name: regression/issue_1079__wait_for_connection_timeout.yml
+  hosts: issue1079
+  gather_facts: false
+  tasks:
+    - name: Wait for connection at start of play
+      wait_for_connection:
+        timeout: 5
+  tags:
+    - issue_1079
+    - wait_for_connection

--- a/tests/ansible/templates/test-targets.j2
+++ b/tests/ansible/templates/test-targets.j2
@@ -40,6 +40,13 @@ ssh_args_canary_file=/tmp/ssh_args_by_inv_{{ '{{' }} inventory_hostname {{ '}}' 
 
 {% set tt = containers[0] %}
 
+[issue1079]
+wait-for-connection ansible_host={{ tt.hostname }} ansible_port={{ tt.port }} ansible_python_interpreter="{{ '{{' }} '{{ tt.python_path }}' | trim {{ '}}' }}"
+
+[issue1079:vars]
+ansible_user=mitogen__has_sudo_nopw
+ansible_password=has_sudo_nopw_password
+
 [tt_targets_bare]
 tt-bare
 


### PR DESCRIPTION
This tightens up our monkey patching `Connection._action` so it's only applied
during `meta: reset_connection` & promptly removed. This fixes "'int' object
has no attribute 'template'" when `ansible.plugins.action.wait_for_connection`
or other code calls `ansible.plugins.connection.ConnectionBase.reset()`.

This could also have switched to `templar=templar` on the temporary action,
rather than `templar=0`, but it's not strictly necessary to fix this bug. I
anticipate other changes doing so soon, to improve interpreter discovery &
templated python interpreter path support.

fixes #1079
refs #1096, #1132