### PR TITLE
docs: Fix "No module named 'imghdr'" when building website

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,8 @@ To avail of fixes in an unreleased version, please download a ZIP file
 In progress (unreleased)
 ------------------------
 
+* :gh:issue:`1209` docs: Fix Netlify build of website
+
 
 v0.3.20 (2025-01-07)
 --------------------

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,0 +1,2 @@
+[build.environment]
+PYTHON_VERSION = "3.8"


### PR DESCRIPTION
Between Mitogen 0.3.19 & 0.3.20 Netlify changed their default Python to 3.13. This broke our deployment of https://mitogen.networkgenomics.com/. The previous default was Python 3.8, based on a recent successful build of https://spiffy-croissant-696d93.netlify.app.

Successful build with this change https://677d0a651a99535aebf94d4a--spiffy-croissant-696d93.netlify.app/ https://app.netlify.com/sites/spiffy-croissant-696d93/deploys/677d0a651a99535aebf94d4a