### PR TITLE
docs: Attempt to configure Netlify build of mitogen.networkgenomics.com

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build.environment]
+PYTHON_VERSION = "3.8"


### PR DESCRIPTION
This site has an unknown build config. Specifically I do not know the value of

- Package directory
- Base directory

these are the locations that Netlify looks for netlify.toml. I've already tried docs/netlify.toml (#1210), unsuccessfully. This attempt is on the basis that Package directory == '/', or less likely that Base directory == '/'.

refs #1209

See
- https://docs.netlify.com/configure-builds/monorepos/#use-a-netlify-configuration-file
- https://docs.netlify.com/configure-builds/file-based-configuration/