### PR TITLE
ansible_mitogen: Fix usage of connection_loader__get.

### DIFF
--- a/ansible_mitogen/loaders.py
+++ b/ansible_mitogen/loaders.py
@@ -99,5 +99,5 @@ from ansible.plugins.loader import shell_loader
 from ansible.plugins.loader import strategy_loader
 
 # These are original, unwrapped implementations
-action_loader__get = action_loader.get
-connection_loader__get = connection_loader.get_with_context
+action_loader__get_with_context = action_loader.get_with_context
+connection_loader__get_with_context = connection_loader.get_with_context

--- a/ansible_mitogen/plugins/connection/mitogen_ssh.py
+++ b/ansible_mitogen/plugins/connection/mitogen_ssh.py
@@ -60,7 +60,7 @@ import ansible_mitogen.loaders
 
 class Connection(ansible_mitogen.connection.Connection):
     transport = 'ssh'
-    vanilla_class = ansible_mitogen.loaders.connection_loader__get(
+    (vanilla_class, load_context) = ansible_mitogen.loaders.connection_loader__get_with_context(
         'ssh',
         class_only=True,
     )

--- a/tests/ansible/regression/all.yml
+++ b/tests/ansible/regression/all.yml
@@ -13,6 +13,7 @@
 - import_playbook: issue_591__setuptools_cwd_crash.yml
 - import_playbook: issue_615__streaming_transfer.yml
 - import_playbook: issue_655__wait_for_connection_error.yml
+- import_playbook: issue_766__get_with_context.yml
 - import_playbook: issue_776__load_plugins_called_twice.yml
 - import_playbook: issue_952__ask_become_pass.yml
 - import_playbook: issue_1066__add_host__host_key_checking.yml

--- a/tests/ansible/regression/issue_655__wait_for_connection_error.yml
+++ b/tests/ansible/regression/issue_655__wait_for_connection_error.yml
@@ -11,7 +11,10 @@
   tasks:
     - meta: end_play
       when:
-        # Podman versions available in Homebrew have dropped macOS 12 support.
+        # Podman versions available in Homebrew require macOS 13+ (Ventura).
+        # https://formulae.brew.sh/formula/podman
+        # See also
+        #   - issue_766__get_with_context.yml
         - ansible_facts.system == 'Darwin'
         - ansible_facts.distribution_version is version('13.0', '<', strict=True)
 

--- a/tests/ansible/regression/issue_766__get_with_context.yml
+++ b/tests/ansible/regression/issue_766__get_with_context.yml
@@ -1,0 +1,64 @@
+# https://github.com/mitogen-hq/mitogen/issues/776
+---
+- name: regression/issue_766__get_with_context.yml
+  hosts: localhost
+  # Gather facts to use *and* to trigger any "could not recover task_vars" error
+  # https://github.com/mitogen-hq/mitogen/pull/1215#issuecomment-2596421111
+  gather_facts: true
+  vars:
+    netconf_container_image: ghcr.io/mitogen-hq/sysrepo-netopeer2:latest
+    netconf_container_name: sysprep
+    netconf_container_port: 8030
+
+  tasks:
+    - meta: end_play
+      when:
+        # Podman can be installed on macOS, but authenticating to gchr.io isn't
+        # worth the trouble right now.
+        # See also
+        #   - issue_655__wait_for_connection_error.yml
+        - ansible_facts.system == 'Darwin'
+
+    - meta: end_play
+      when:
+        # A failure during the ansible.netcommon.netconf_get task, when run
+        # with Ansible 4 (ansible-core 2.11) & associated collections.
+        # ansible.module_utils.connection.ConnectionError: Method not found
+        # https://github.com/mitogen-hq/mitogen/actions/runs/12854359099/job/35838635886
+        - ansible_version.full is version('2.11', '>=', strict=True)
+        - ansible_version.full is version('2.12', '<', strict=True)
+
+    - block:
+        - name: Start container
+          command:
+            cmd: >-
+              podman run
+              --name "{{ netconf_container_name }}"
+              --detach
+              --rm
+              --publish "{{ netconf_container_port }}:830"
+              "{{ netconf_container_image }}"
+          changed_when: true
+
+        - name: Wait for container
+          # TODO robust condition. wait_for + search_regex? wait_for_connection?
+          wait_for:
+            timeout: 5
+
+        - name: Get running configuration and state data
+          vars:
+            ansible_connection: netconf
+            ansible_user: netconf
+            ansible_password: netconf
+            ansible_port: "{{ netconf_container_port }}"
+            ansible_host_key_checking: false
+            ansible_python_interpreter: "{{ ansible_playbook_python }}"
+          ansible.netcommon.netconf_get:
+
+      always:
+        - name: Cleanup container
+          command:
+            cmd: podman stop "{{ netconf_container_name }}"
+          changed_when: true
+  tags:
+    - issue_766

--- a/tests/ansible/requirements.txt
+++ b/tests/ansible/requirements.txt
@@ -1,7 +1,13 @@
-paramiko==2.3.2  # Last 2.6-compat version.
+paramiko==2.12.0;           python_version <= '2.7'
+paramiko==3.5.0;            python_version >= '3.6'
+
 # Incompatible with pip >= 72, due to removal of `setup.py test`:
 #   ModuleNotFoundError: No module named 'setuptools.command.test'
 # https://github.com/pypa/setuptools/issues/4519
 hdrhistogram==0.6.1
+
+ncclient==0.6.13; python_version <= '2.7'
+ncclient==0.6.16; python_version > '2.7'
+
 PyYAML==3.11; python_version < '2.7'
 PyYAML==5.3.1; python_version >= '2.7'  # Latest release (Jan 2021)


### PR DESCRIPTION
This PR revives mitogen-hq/mitogen#976 and updates the proposed fix in both the SSH and kubectl connection methods.

As a short recap, get_with_context returns a named tuple as of Ansible 2.10, which necessitates a small change in how it's accessed in Mitogen.

Furthermore, certain connections use both a local and a remote connection. This would cause issues in the same code path due to how Mitogen transmutes action types at runtime - this has also been fixed.

This fixes https://github.com/mitogen-hq/mitogen/issues/766, https://github.com/mitogen-hq/mitogen/issues/662, https://github.com/mitogen-hq/mitogen/issues/342, and https://github.com/mitogen-hq/mitogen/issues/1094.