### PR TITLE
packaging: Avoid ast module, requires Python = 2.6

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,7 @@ In progress (unreleased)
 ------------------------
 
 * :gh:issue:`1121` :mod:`mitogen`: Log skipped :py:mod:`termios` attributes
+* :gh:issue:`1238` packaging: Avoid :py:mod:`ast`, requires Python = 2.6
 
 
 v0.3.22 (2025-02-04)

--- a/setup.py
+++ b/setup.py
@@ -26,20 +26,22 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import ast
 import os
+import re
 
 from setuptools import find_packages, setup
 
 
 def grep_version():
     path = os.path.join(os.path.dirname(__file__), 'mitogen/__init__.py')
+    version_pattern = re.compile(
+        r"__version__ = \((\d+), (\d+), (\d+)(?:, '(dev)')?\)",
+    )
     with open(path) as fp:
-        for line in fp:
-            if line.startswith('__version__'):
-                _, _, s = line.partition('=')
-                parts = ast.literal_eval(s.strip())
-                return '.'.join(str(part) for part in parts)
+        match = version_pattern.search(fp.read())
+    if match is None:
+        raise ValueError('Could not find __version__ string in %s', path)
+    return '.'.join(str(part) for part in match.groups())
 
 
 def long_description():


### PR DESCRIPTION
fixes #1238, refs #1236