### PR TITLE
chore: Ignore locally installed collections, dummy modules, etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.ansible/
 .coverage
 .tox
 .venv


### PR DESCRIPTION
With mock_modules ansible-lint creates files here, e.g.

```console
$ find .ansible
.ansible
.ansible/roles
.ansible/modules
.ansible/modules/test_echo_module.py
.ansible/modules/custom_python_leaky_class_vars.py
.ansible/modules/custom_python_new_style_module.py
...
```