### PR TITLE
docs: Fix website download link when there is a pre-release

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,8 +7,9 @@ sys.path.append('.')
 def changelog_version(path, encoding='utf-8'):
     "Return the 1st *stable* (not pre, dev) version in the changelog"
     # See also grep_version() in setup.py
+    # e.g. "0.1.2, (1999-12-31)\n"
     version_pattern = re.compile(
-        r'^v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)',
+        r'^v(?P<version>\d+\.\d+\.\d+) \((?P<date>\d\d\d\d-\d\d-\d\d)\)$',
         re.MULTILINE,
     )
 


### PR DESCRIPTION
The previous regex was incorrectly matching a prefix (e.g. 1.2.3) of a pre-release (e.g. 1.2.3a1, 1.2.3rc1).

fixes #1276