### PR TITLE
Keep compatibility with `setuptools` tagging wheels with `py2.py3`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bdist_wheel]
-universal=1
+python_tag = py2.py3
 
 [coverage:run]
 branch = true


### PR DESCRIPTION
Modern versions of `setuptools` emit a warning when the `universal = 1` option of `bdist_wheel` is used. This warning will turn into an error on Aug 30, 2025.

The only function of `universal = 1` is assigning the dual `py2.py3` tag to the wheels. It does not perform any content or metadata compatibility validation that might be related to this.

It is possible to keep producing same-tagged wheels by setting the non-deprecated `python_tag` option instead, which is what this PR does.

Fixes #1283

Ref https://github.com/pypa/setuptools/pull/4939