### PR TITLE
Update missing host key checking argument in docs/ansible_detailed.rst

### DIFF
--- a/docs/ansible_detailed.rst
+++ b/docs/ansible_detailed.rst
@@ -1018,6 +1018,8 @@ Like the :ans:conn:`ssh` except connection delegation is supported.
 * ``ansible_ssh_private_key_file``
 * ``ansible_ssh_pass``, ``ansible_ssh_password``, ``ansible_password``
   (default: assume passwordless)
+* ``ansible_ssh_host_key_checking``, ``ansible_host_key_checking`` (default: 
+  :data:`True`)
 * ``ssh_args``, ``ssh_common_args``, ``ssh_extra_args``
 * ``mitogen_mask_remote_name``: if :data:`True`, mask the identity of the
   Ansible controller process on remote machines. To simplify diagnostics,


### PR DESCRIPTION
The arguments `ansible_ssh_host_key_checking` and `ansible_host_key_checking` are missing in the documentation, while being introduced last year with the PR https://github.com/mitogen-hq/mitogen/issues/1066


