### PR TITLE
CI: Switch to archived Debian 10 (buster) apt repository

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,6 +32,8 @@ Running Ansible 12 + Mitogen will currently print a deprecation warning
 Ansible + Mitogen will still work for now. Mitogen is considering alternatives
 to strategy plugins under :gh:issue:`1278`.
 
+* :gh:issue:`1303` CI: Switch to archived Debian 10 (buster) apt repository
+
 
 v0.3.25a3 (2025-07-02)
 ----------------------

--- a/tests/ansible/hosts/group_vars/debian10.yml
+++ b/tests/ansible/hosts/group_vars/debian10.yml
@@ -1,0 +1,4 @@
+package_manager_repos:
+  - dest: /etc/apt/sources.list
+    content: |
+      deb http://archive.debian.org/debian buster main contrib non-free


### PR DESCRIPTION
The Debian project recently removed this EOL version from the live mirrors.
fixes #1303