### PR TITLE
mitogen: Fix non-blocking IO errors in first stage of bootstrap

### DIFF
--- a/.ci/ci_lib.py
+++ b/.ci/ci_lib.py
@@ -41,6 +41,8 @@ IMAGE_TEMPLATE = os.environ.get(
     'MITOGEN_TEST_IMAGE_TEMPLATE',
     'ghcr.io/mitogen-hq/%(distro)s-test:2021',
 )
+SUDOERS_DEFAULTS_SRC = './tests/image_prep/files/sudoers_defaults'
+SUDOERS_DEFAULTS_DEST = '/etc/sudoers.d/mitogen_test_defaults'
 TESTS_SSH_PRIVATE_KEY_FILE = os.path.join(GIT_ROOT, 'tests/data/docker/mitogen__has_sudo_pubkey.key')
 
 

--- a/.ci/ci_lib.py
+++ b/.ci/ci_lib.py
@@ -58,6 +58,7 @@ def _have_cmd(args):
     try:
         subprocess.run(
             args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            check=True,
         )
     except OSError as exc:
         if exc.errno == errno.ENOENT:

--- a/.ci/mitogen_tests.py
+++ b/.ci/mitogen_tests.py
@@ -2,6 +2,7 @@
 # Run the Mitogen tests.
 
 import os
+import subprocess
 
 import ci_lib
 
@@ -12,6 +13,14 @@ os.environ.update({
 
 if not ci_lib.have_docker():
     os.environ['SKIP_DOCKER_TESTS'] = '1'
+
+subprocess.check_call(
+    "umask 0022; sudo cp '%s' '%s'"
+    % (ci_lib.SUDOERS_DEFAULTS_SRC, ci_lib.SUDOERS_DEFAULTS_DEST),
+    shell=True,
+)
+subprocess.check_call(['sudo', 'visudo', '-cf', ci_lib.SUDOERS_DEFAULTS_DEST])
+subprocess.check_call(['sudo', '-l'])
 
 interesting = ci_lib.get_interesting_procs()
 ci_lib.run('./run_tests -v')

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,8 @@ To avail of fixes in an unreleased version, please download a ZIP file
 In progress (unreleased)
 ------------------------
 
+* :gh:issue:`1306` :mod:`ansible_mitogen`: Fix non-blocking IO errors in
+  first stage of bootstrap
 * :gh:issue:`1306` CI: Report sudo version on Ansible targets
 * :gh:issue:`1306` CI: Move sudo test users defaults into ``/etc/sudoers.d``
 * :gh:issue:`1306` preamble_size: Fix variability of measured command size

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,7 @@ In progress (unreleased)
 
 * :gh:issue:`1306` CI: Report sudo version on Ansible targets
 * :gh:issue:`1306` CI: Move sudo test users defaults into ``/etc/sudoers.d``
+* :gh:issue:`1306` preamble_size: Fix variability of measured command size
 
 
 v0.3.27 (2025-08-20)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,7 @@ In progress (unreleased)
 * :gh:issue:`1306` CI: Move sudo test users defaults into ``/etc/sudoers.d``
 * :gh:issue:`1306` preamble_size: Fix variability of measured command size
 * :gh:issue:`1306` tests: Count bytes written in ``stdio_test.StdIOTest``
+* :gh:issue:`1306` tests: Check stdio is blocking in sudo contexts
 
 
 v0.3.27 (2025-08-20)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,7 @@ In progress (unreleased)
 * :gh:issue:`1306` CI: Report sudo version on Ansible targets
 * :gh:issue:`1306` CI: Move sudo test users defaults into ``/etc/sudoers.d``
 * :gh:issue:`1306` preamble_size: Fix variability of measured command size
+* :gh:issue:`1306` tests: Count bytes written in ``stdio_test.StdIOTest``
 
 
 v0.3.27 (2025-08-20)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,7 @@ In progress (unreleased)
 ------------------------
 
 * :gh:issue:`1306` CI: Report sudo version on Ansible targets
+* :gh:issue:`1306` CI: Move sudo test users defaults into ``/etc/sudoers.d``
 
 
 v0.3.27 (2025-08-20)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,8 @@ To avail of fixes in an unreleased version, please download a ZIP file
 In progress (unreleased)
 ------------------------
 
+* :gh:issue:`1306` CI: Report sudo version on Ansible targets
+
 
 v0.3.27 (2025-08-20)
 --------------------

--- a/preamble_size.py
+++ b/preamble_size.py
@@ -18,6 +18,16 @@ import mitogen.service
 import mitogen.ssh
 import mitogen.sudo
 
+
+class Table(object):
+    HEADERS = (' ', 'Original', 'Minimized', 'Compressed')
+    HEAD_FMT = '{:20} {:^15}  {:^19}  {:^19}'
+    ROW_FMT =  '%-20s %6i %5.1fKiB  %5i %4.1fKiB %4.1f%%  %5i %4.1fKiB %4.1f%%'
+
+    def header(self):
+        return self.HEAD_FMT.format(*self.HEADERS)
+
+
 router = mitogen.master.Router()
 context = mitogen.parent.Context(router, 0)
 options = mitogen.ssh.Options(max_message_size=0, hostname='foo')
@@ -36,16 +46,8 @@ if '--dump' in sys.argv:
     exit()
 
 
-print(
-    '                           '
-    ' '
-    '  Original   '
-    '  '
-    '     Minimized     '
-    '  '
-    '    Compressed     '
-)
-
+table = Table()
+print(table.header())
 for mod in (
         mitogen.parent,
         mitogen.fork,
@@ -63,13 +65,7 @@ for mod in (
     compressed = zlib.compress(minimized.encode(), 9)
     compressed_size = len(compressed)
     print(
-        '%-25s'
-        ' '
-        '%5i %4.1fKiB'
-        '  '
-        '%5i %4.1fKiB %.1f%%'
-        '  '
-        '%5i %4.1fKiB %.1f%%'
+        table.ROW_FMT
     % (
         mod.__name__,
         original_size,

--- a/preamble_size.py
+++ b/preamble_size.py
@@ -8,6 +8,7 @@ import inspect
 import sys
 import zlib
 
+import mitogen.core
 import mitogen.fakessh
 import mitogen.fork
 import mitogen.master
@@ -35,7 +36,7 @@ conn = mitogen.ssh.Connection(options, router)
 conn.context = context
 
 print('SSH command size: %s' % (len(' '.join(conn.get_boot_command())),))
-print('Bootstrap (mitogen.core) size: %s (%.2fKiB)' % (
+print('Preamble (mitogen.core + econtext) size: %s (%.2fKiB)' % (
     len(conn.get_preamble()),
     len(conn.get_preamble()) / 1024.0,
 ))
@@ -49,6 +50,7 @@ if '--dump' in sys.argv:
 table = Table()
 print(table.header())
 for mod in (
+        mitogen.core,
         mitogen.parent,
         mitogen.fork,
         mitogen.ssh,

--- a/preamble_size.py
+++ b/preamble_size.py
@@ -31,7 +31,11 @@ class Table(object):
 
 router = mitogen.master.Router()
 context = mitogen.parent.Context(router, 0)
-options = mitogen.ssh.Options(max_message_size=0, hostname='foo')
+options = mitogen.ssh.Options(
+    hostname='foo',
+    max_message_size=0,
+    remote_name='alice@host:1234',
+)
 conn = mitogen.ssh.Connection(options, router)
 conn.context = context
 

--- a/tests/ansible/setup/report_targets.yml
+++ b/tests/ansible/setup/report_targets.yml
@@ -13,3 +13,23 @@
     - debug: {var: ansible_facts.osversion}
     - debug: {var: ansible_facts.python}
     - debug: {var: ansible_facts.system}
+
+- name: Check target versions
+  hosts: localhost:test-targets
+  check_mode: false
+  tasks:
+    - name: Get command versions
+      command:
+        cmd: "{{ item.cmd }}"
+      changed_when: false
+      check_mode: false
+      loop:
+        - cmd: sudo -V
+      register: command_versions
+
+    - name: Show command versions
+      debug:
+        msg: |
+          cmd: {{ item.item.cmd }}
+          {{ item.stdout }}
+      loop: "{{ command_versions.results }}"

--- a/tests/data/stdio_checks.py
+++ b/tests/data/stdio_checks.py
@@ -3,9 +3,24 @@ import os
 import sys
 
 
+def _shout_stdout_py3(size):
+    nwritten = sys.stdout.write('A' * size)
+    return nwritten
+
+
+def _shout_stdout_py2(size):
+    shout = 'A' * size
+    nwritten = 0
+    while nwritten < size:
+        nwritten += os.write(sys.stdout.fileno(), shout[-nwritten:])
+    return nwritten
+
+
 def shout_stdout(size):
-    sys.stdout.write('A' * size)
-    return 'success'
+    if sys.version_info > (3, 0):
+        return _shout_stdout_py3(size)
+    else:
+        return _shout_stdout_py2(size)
 
 
 def file_is_blocking(fobj):

--- a/tests/first_stage_test.py
+++ b/tests/first_stage_test.py
@@ -1,5 +1,6 @@
 import subprocess
 
+import mitogen.core
 import mitogen.parent
 from mitogen.core import b
 
@@ -21,14 +22,18 @@ class CommandLineTest(testlib.RouterMixin, testlib.TestCase):
         conn.context = mitogen.core.Context(None, 123)
         args = conn.get_boot_command()
 
-        # Executing the boot command will print "EC0" and expect to read from
-        # stdin, which will fail because it's pointing at /dev/null, causing
-        # the forked child to crash with an EOFError and disconnect its write
-        # pipe. The forked and freshly execed parent will get a 0-byte read
-        # from the pipe, which is a valid script, and therefore exit indicating
-        # success.
+        # The boot command should write an ECO marker to stdout, read the
+        # preamble from stdin, then execute it.
 
-        fp = open("/dev/null", "r")
+        # This test attaches /dev/zero to stdin to create a specific failure
+        # 1. Fork child reads PREAMBLE_COMPRESSED_LEN bytes of junk (all `\0`)
+        # 2. Fork child crashes (trying to decompress the junk data)
+        # 3. Fork child's file descriptors (write pipes) are closed by the OS
+        # 4. Fork parent does `dup(<read pipe>, <stdin>)` and `exec(<python>)`
+        # 5. Python reads `b''` (i.e. EOF) from stdin (a closed pipe)
+        # 6. Python runs `''` (a valid script) and exits with success
+
+        fp = open("/dev/zero", "r")
         try:
             proc = subprocess.Popen(args,
                 stdin=fp,
@@ -39,6 +44,9 @@ class CommandLineTest(testlib.RouterMixin, testlib.TestCase):
             self.assertEqual(0, proc.returncode)
             self.assertEqual(stdout,
                 mitogen.parent.BootstrapProtocol.EC0_MARKER+b('\n'))
-            self.assertIn(b("Error -5 while decompressing data"), stderr)
+            self.assertIn(
+                b("Error -3 while decompressing data"),  # Unknown compression method
+                stderr,
+            )
         finally:
             fp.close()

--- a/tests/image_prep/_user_accounts.yml
+++ b/tests/image_prep/_user_accounts.yml
@@ -157,15 +157,14 @@
             owner: mitogen__has_sudo_pubkey
             group: mitogen__group
 
-    - name: Configure sudoers defaults
-      blockinfile:
-        path: /etc/sudoers
-        marker: "# {mark} Mitogen test defaults"
-        block: |
-          Defaults>mitogen__pw_required targetpw
-          Defaults>mitogen__require_tty requiretty
-          Defaults>mitogen__require_tty_pw_required requiretty,targetpw
+    - name: Configure sudoers
+      copy:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+        mode: ug=r,o=
         validate: '/usr/sbin/visudo -cf %s'
+      with_items:
+        - {src: sudoers_defaults, dest: /etc/sudoers.d/mitogen_test_defaults}
 
     - name: Configure sudoers users
       blockinfile:

--- a/tests/image_prep/files/sudoers_defaults
+++ b/tests/image_prep/files/sudoers_defaults
@@ -1,3 +1,7 @@
+# Testing non-blocking stdio during bootstrap
+# https://github.com/mitogen-hq/mitogen/issues/1306
+Defaults log_output
+
 Defaults>mitogen__pw_required targetpw
 Defaults>mitogen__require_tty requiretty
 Defaults>mitogen__require_tty_pw_required requiretty,targetpw

--- a/tests/image_prep/files/sudoers_defaults
+++ b/tests/image_prep/files/sudoers_defaults
@@ -1,0 +1,3 @@
+Defaults>mitogen__pw_required targetpw
+Defaults>mitogen__require_tty requiretty
+Defaults>mitogen__require_tty_pw_required requiretty,targetpw

--- a/tests/stdio_test.py
+++ b/tests/stdio_test.py
@@ -1,28 +1,46 @@
+import unittest
+
 import testlib
 
 import stdio_checks
 
 
-class StdIOTest(testlib.RouterMixin, testlib.TestCase):
+class StdIOMixin(testlib.RouterMixin):
     """
     Test that stdin, stdout, and stderr conform to common expectations,
     such as blocking IO.
     """
-    def test_can_write_stdout_1_mib(self):
+    def check_can_write_stdout_1_mib(self, context):
         """
         Writing to stdout should not raise EAGAIN. Regression test for
         https://github.com/mitogen-hq/mitogen/issues/712.
         """
         size = 1 * 2**20
-        context = self.router.local()
         nwritten = context.call(stdio_checks.shout_stdout, size)
         self.assertEqual(nwritten, size)
 
-    def test_stdio_is_blocking(self):
-        context = self.router.local()
+    def check_stdio_is_blocking(self, context):
         stdin_blocking, stdout_blocking, stderr_blocking = context.call(
             stdio_checks.stdio_is_blocking,
         )
         self.assertTrue(stdin_blocking)
         self.assertTrue(stdout_blocking)
         self.assertTrue(stderr_blocking)
+
+
+class LocalTest(StdIOMixin, testlib.TestCase):
+    def test_can_write_stdout_1_mib(self):
+        self.check_can_write_stdout_1_mib(self.router.local())
+
+    def test_stdio_is_blocking(self):
+        self.check_stdio_is_blocking(self.router.local())
+
+
+class SudoTest(StdIOMixin, testlib.TestCase):
+    @unittest.skipIf(not testlib.have_sudo_nopassword(), 'Needs passwordless sudo')
+    def test_can_write_stdout_1_mib(self):
+        self.check_can_write_stdout_1_mib(self.router.sudo())
+
+    @unittest.skipIf(not testlib.have_sudo_nopassword(), 'Needs passwordless sudo')
+    def test_stdio_is_blocking(self):
+        self.check_stdio_is_blocking(self.router.sudo())

--- a/tests/stdio_test.py
+++ b/tests/stdio_test.py
@@ -15,8 +15,8 @@ class StdIOTest(testlib.RouterMixin, testlib.TestCase):
         """
         size = 1 * 2**20
         context = self.router.local()
-        result = context.call(stdio_checks.shout_stdout, size)
-        self.assertEqual('success', result)
+        nwritten = context.call(stdio_checks.shout_stdout, size)
+        self.assertEqual(nwritten, size)
 
     def test_stdio_is_blocking(self):
         context = self.router.local()

--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -160,6 +160,7 @@ def _have_cmd(args):
     try:
         subprocess.run(
             args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            check=True,
         )
     except OSError as exc:
         if exc.errno == errno.ENOENT:

--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -179,6 +179,15 @@ def have_python3():
     return _have_cmd(['python3'])
 
 
+def have_sudo_nopassword():
+    """
+    Return True if we can run `sudo` with no password, otherwise False.
+
+    Any cached credentials are ignored.
+    """
+    return _have_cmd(['sudo', '-kn', 'true'])
+
+
 def retry(fn, on, max_attempts, delay):
     for i in range(max_attempts):
         try:


### PR DESCRIPTION
When /etc/sudoers has log_output (or similar) enabled the process spawned by `ctx.sudo()` via `mitogen.parent.Connection.start_child()` receives a stdin that is in non-blocking mode. The immediate symptom is that `os.openfd(0, ...).read(n)` sometimes returns `None`, causing the first stage to raise an unhandled `TypeError`.

The fix (for now) is to use `select.select()` in as while loop to read stdin. This increases the command size slightly, but I think it's a reasonable tradeoff until/unless the cause is more fully understood.

All CI tests are now run with sudoers log_output enabled, in order to catch regressions. `first_stage_test.CommandLineTest` has been amended, because it relied on implementation details of the bootstrap process that are no longer true.

Fixes #1306, thanks to @Forgetyk for their detailed error reporting, diagnosis, and initial PR #1299

## Preamble size

### Before
```
SSH command size: 755
Preamble (mitogen.core + econtext) size: 18227 (17.80KiB)

                        Original           Minimized           Compressed
mitogen.core         152218 148.7KiB  68437 66.8KiB 45.0%  18124 17.7KiB 11.9%
mitogen.parent        98853  96.5KiB  51103 49.9KiB 51.7%  12881 12.6KiB 13.0%
mitogen.fork           8445   8.2KiB   4139  4.0KiB 49.0%   1652  1.6KiB 19.6%
mitogen.ssh           10827  10.6KiB   6893  6.7KiB 63.7%   2099  2.0KiB 19.4%
mitogen.sudo          12089  11.8KiB   5924  5.8KiB 49.0%   2249  2.2KiB 18.6%
mitogen.select        12325  12.0KiB   2929  2.9KiB 23.8%    964  0.9KiB  7.8%
mitogen.service       41581  40.6KiB  22398 21.9KiB 53.9%   5847  5.7KiB 14.1%
mitogen.fakessh       15767  15.4KiB   8149  8.0KiB 51.7%   2676  2.6KiB 17.0%
mitogen.master        55317  54.0KiB  28846 28.2KiB 52.1%   7528  7.4KiB 13.6%
```

### After
```
SSH command size: 798
Preamble (mitogen.core + econtext) size: 18227 (17.80KiB)

                        Original           Minimized           Compressed     
mitogen.core         152218 148.7KiB  68437 66.8KiB 45.0%  18124 17.7KiB 11.9%
mitogen.parent        98944  96.6KiB  51180 50.0KiB 51.7%  12910 12.6KiB 13.0%
mitogen.fork           8445   8.2KiB   4139  4.0KiB 49.0%   1652  1.6KiB 19.6%
mitogen.ssh           10827  10.6KiB   6893  6.7KiB 63.7%   2099  2.0KiB 19.4%
mitogen.sudo          12089  11.8KiB   5924  5.8KiB 49.0%   2249  2.2KiB 18.6%
mitogen.select        12325  12.0KiB   2929  2.9KiB 23.8%    964  0.9KiB  7.8%
mitogen.service       41581  40.6KiB  22398 21.9KiB 53.9%   5847  5.7KiB 14.1%
mitogen.fakessh       15767  15.4KiB   8149  8.0KiB 51.7%   2676  2.6KiB 17.0%
mitogen.master        55317  54.0KiB  28846 28.2KiB 52.1%   7528  7.4KiB 13.6%
```