### PR TITLE
CI: Abbreviate Github Actions job names

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,23 +25,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Ans_27_210
-            tox_env: py27-mode_ansible-ansible2.10
-          - name: Ans_27_4
-            tox_env: py27-mode_ansible-ansible4
+          - tox_env: py27-m_ans-ans2.10
+          - tox_env: py27-m_ans-ans4
 
-          - name: Ans_36_210
+          - tox_env: py36-m_ans-ans2.10
             python_version: '3.6'
-            tox_env: py36-mode_ansible-ansible2.10
-          - name: Ans_36_4
+          - tox_env: py36-m_ans-ans4
             python_version: '3.6'
-            tox_env: py36-mode_ansible-ansible4
 
-          - name: Mito_27
-            tox_env: py27-mode_mitogen
-          - name: Mito_36
+          - tox_env: py27-m_mtg
+          - tox_env: py36-m_mtg
             python_version: '3.6'
-            tox_env: py36-mode_mitogen
 
     steps:
       - uses: actions/checkout@v4
@@ -98,7 +92,7 @@ jobs:
         run: |
           set -o errexit -o nounset -o pipefail
 
-          # Tox environment name (e.g. py312-mode_mitogen) -> Python executable name (e.g. python3.12)
+          # Tox environment name (e.g. py312-m_mtg) -> Python executable name (e.g. python3.12)
           PYTHON=$(python -c 'import re; print(re.sub(r"^py([23])([0-9]{1,2}).*", r"python\1.\2", "${{ matrix.tox_env }}"))')
 
           if [[ -z $PYTHON ]]; then
@@ -123,7 +117,7 @@ jobs:
         run: |
           set -o errexit -o nounset -o pipefail
 
-          # Tox environment name (e.g. py312-mode_mitogen) -> Python executable name (e.g. python3.12)
+          # Tox environment name (e.g. py312-m_mtg) -> Python executable name (e.g. python3.12)
           PYTHON=$(python -c 'import re; print(re.sub(r"^py([23])([0-9]{1,2}).*", r"python\1.\2", "${{ matrix.tox_env }}"))')
 
           if [[ -z $PYTHON ]]; then
@@ -147,50 +141,36 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Ans_311_210
+          - tox_env: py311-m_ans-ans2.10
             python_version: '3.11'
-            tox_env: py311-mode_ansible-ansible2.10
-          - name: Ans_311_3
+          - tox_env: py311-m_ans-ans3
             python_version: '3.11'
-            tox_env: py311-mode_ansible-ansible3
-          - name: Ans_311_4
+          - tox_env: py311-m_ans-ans4
             python_version: '3.11'
-            tox_env: py311-mode_ansible-ansible4
-          - name: Ans_311_5
+          - tox_env: py311-m_ans-ans5
             python_version: '3.11'
-            tox_env: py311-mode_ansible-ansible5
-          - name: Ans_313_6
+          - tox_env: py313-m_ans-ans6
             python_version: '3.13'
-            tox_env: py313-mode_ansible-ansible6
-          - name: Ans_313_7
+          - tox_env: py313-m_ans-ans7
             python_version: '3.13'
-            tox_env: py313-mode_ansible-ansible7
-          - name: Ans_313_8
+          - tox_env: py313-m_ans-ans8
             python_version: '3.13'
-            tox_env: py313-mode_ansible-ansible8
-          - name: Ans_313_9
+          - tox_env: py313-m_ans-ans9
             python_version: '3.13'
-            tox_env: py313-mode_ansible-ansible9
-          - name: Ans_313_10
+          - tox_env: py313-m_ans-ans10
             python_version: '3.13'
-            tox_env: py313-mode_ansible-ansible10
-          - name: Ans_313_11
+          - tox_env: py313-m_ans-ans11
             python_version: '3.13'
-            tox_env: py313-mode_ansible-ansible11
-          - name: Ans_313_12
+          - tox_env: py313-m_ans-ans12
             python_version: '3.13'
-            tox_env: py313-mode_ansible-ansible12
 
-          - name: Van_313_11
+          - tox_env: py313-m_ans-ans11-s_lin
             python_version: '3.13'
-            tox_env: py313-mode_ansible-ansible11-strategy_linear
-          - name: Van_313_12
+          - tox_env: py313-m_ans-ans12-s_lin
             python_version: '3.13'
-            tox_env: py313-mode_ansible-ansible12-strategy_linear
 
-          - name: Mito_313
+          - tox_env: py313-m_mtg
             python_version: '3.13'
-            tox_env: py313-mode_mitogen
 
     steps:
       - uses: actions/checkout@v4
@@ -234,7 +214,7 @@ jobs:
         run: |
           set -o errexit -o nounset -o pipefail
 
-          # Tox environment name (e.g. py312-mode_mitogen) -> Python executable name (e.g. python3.12)
+          # Tox environment name (e.g. py312-m_mtg) -> Python executable name (e.g. python3.12)
           PYTHON=$(python -c 'import re; print(re.sub(r"^py([23])([0-9]{1,2}).*", r"python\1.\2", "${{ matrix.tox_env }}"))')
 
           if [[ -z $PYTHON ]]; then
@@ -250,7 +230,7 @@ jobs:
         run: |
           set -o errexit -o nounset -o pipefail
 
-          # Tox environment name (e.g. py312-mode_mitogen) -> Python executable name (e.g. python3.12)
+          # Tox environment name (e.g. py312-m_mtg) -> Python executable name (e.g. python3.12)
           PYTHON=$(python -c 'import re; print(re.sub(r"^py([23])([0-9]{1,2}).*", r"python\1.\2", "${{ matrix.tox_env }}"))')
 
           if [[ -z $PYTHON ]]; then
@@ -270,22 +250,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Mito_313
-            tox_env: py313-mode_mitogen
-
-          - name: Loc_313_11
+          - tox_env: py313-m_lcl-ans11
             sshpass_version: "1.10"
-            tox_env: py313-mode_localhost-ansible11
-
-          - name: Van_313_11
+          - tox_env: py313-m_lcl-ans11-s_lin
             sshpass_version: "1.10"
-            tox_env: py313-mode_localhost-ansible11-strategy_linear
+          - tox_env: py313-m_lcl-ans12
+          - tox_env: py313-m_lcl-ans12-s_lin
 
-          - name: Loc_313_12
-            tox_env: py313-mode_localhost-ansible12
-
-          - name: Van_313_12
-            tox_env: py313-mode_localhost-ansible12-strategy_linear
+          - tox_env: py313-m_mtg
 
     steps:
       - uses: actions/checkout@v4
@@ -325,7 +297,7 @@ jobs:
         run: |
           set -o errexit -o nounset -o pipefail
 
-          # Tox environment name (e.g. py312-mode_mitogen) -> Python executable name (e.g. python3.12)
+          # Tox environment name (e.g. py312-m_mtg) -> Python executable name (e.g. python3.12)
           PYTHON=$(python -c 'import re; print(re.sub(r"^py([23])([0-9]{1,2}).*", r"python\1.\2", "${{ matrix.tox_env }}"))')
 
           if [[ -z $PYTHON ]]; then
@@ -341,7 +313,7 @@ jobs:
         run: |
           set -o errexit -o nounset -o pipefail
 
-          # Tox environment name (e.g. py312-mode_mitogen) -> Python executable name (e.g. python3.12)
+          # Tox environment name (e.g. py312-m_mtg) -> Python executable name (e.g. python3.12)
           PYTHON=$(python -c 'import re; print(re.sub(r"^py([23])([0-9]{1,2}).*", r"python\1.\2", "${{ matrix.tox_env }}"))')
 
           if [[ -z $PYTHON ]]; then

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,8 @@ To avail of fixes in an unreleased version, please download a ZIP file
 In progress (unreleased)
 ========================
 
+* :gh:issue:`1318` CI: Abbreviate Github Actions job names
+
 
 v0.3.25 (2025-07-29)
 --------------------

--- a/tox.ini
+++ b/tox.ini
@@ -55,10 +55,10 @@
 [tox]
 envlist =
     init,
-    py{27,36}-mode_ansible-ansible{2.10,3,4},
-    py{311}-mode_ansible-ansible{2.10,3,4,5},
-    py{313}-mode_ansible-ansible{6,7,8,9,10,11,12},
-    py{27,36,313}-mode_mitogen,
+    py{27,36}-m_ans-ans{2.10,3,4}
+    py{311}-m_ans-ans{2.10,3-5}
+    py{313}-m_ans-ans{6-12}
+    py{27,36,313}-m_mtg
     report,
 
 [testenv]
@@ -76,28 +76,28 @@ basepython =
     py313: python3.13
 deps =
     -r{toxinidir}/tests/requirements.txt
-    mode_ansible: -r{toxinidir}/tests/ansible/requirements.txt
-    ansible2.10: ansible~=2.10.0
-    ansible3: ansible~=3.0
-    ansible4: ansible~=4.0
-    ansible5: ansible~=5.0
+    m_ans: -r{toxinidir}/tests/ansible/requirements.txt
+    ans2.10: ansible~=2.10.0
+    ans3: ansible~=3.0
+    ans4: ansible~=4.0
+    ans5: ansible~=5.0
     # From Ansible 6 PyPI distributions include a wheel
-    ansible6: ansible~=6.0
-    ansible7: ansible~=7.0
-    ansible8: ansible~=8.0
-    ansible9: ansible~=9.0
-    ansible10: ansible~=10.0
-    ansible11: ansible~=11.0
-    ansible12: ansible>=12.0.0b2
+    ans6: ansible~=6.0
+    ans7: ansible~=7.0
+    ans8: ansible~=8.0
+    ans9: ansible~=9.0
+    ans10: ansible~=10.0
+    ans11: ansible~=11.0
+    ans12: ansible>=12.0.0b2
 install_command =
     python -m pip --no-python-version-warning --disable-pip-version-check install {opts} {packages}
 commands_pre =
     mode_debops_common: {toxinidir}/.ci/debops_common_install.py
 commands =
-    mode_ansible: {toxinidir}/.ci/ansible_tests.py
+    m_ans: {toxinidir}/.ci/ansible_tests.py
     mode_debops_common: {toxinidir}/.ci/debops_common_tests.py
-    mode_localhost: {toxinidir}/.ci/localhost_ansible_tests.py
-    mode_mitogen: {toxinidir}/.ci/mitogen_tests.py
+    m_lcl: {toxinidir}/.ci/localhost_ansible_tests.py
+    m_mtg: {toxinidir}/.ci/mitogen_tests.py
 passenv =
     ANSIBLE_*
     HOME
@@ -111,20 +111,18 @@ setenv =
     PIP_CONSTRAINT={toxinidir}/tests/constraints.txt
     # Superceded in Ansible >= 6 (ansible-core >= 2.13) by result_format=yaml
     # Deprecated in Ansible 12 (ansible-core 2.19)
-    ansible{2.10,3-5}: DEFAULT_STDOUT_CALLBACK=yaml
+    ans{2.10,3,4,5}: ANSIBLE_STDOUT_CALLBACK=yaml
     # Print warning on the first occurence at each module:linenno in Mitogen. Available Python 2.7, 3.2+.
     PYTHONWARNINGS=default:::ansible_mitogen,default:::mitogen
     # Ansible 6 - 8 (ansible-core 2.13 - 2.15) require Python 2.7 or >= 3.5 on targets
-    ansible6: MITOGEN_TEST_DISTRO_SPECS=centos7 centos8 debian9 debian10 debian11 ubuntu1604 ubuntu1804 ubuntu2004
-    ansible7: MITOGEN_TEST_DISTRO_SPECS=centos7 centos8 debian9 debian10 debian11 ubuntu1604 ubuntu1804 ubuntu2004
-    ansible8: MITOGEN_TEST_DISTRO_SPECS=centos7 centos8 debian9 debian10 debian11 ubuntu1604 ubuntu1804 ubuntu2004
+    ans{6,7,8}: MITOGEN_TEST_DISTRO_SPECS=centos7 centos8 debian9 debian10 debian11 ubuntu1604 ubuntu1804 ubuntu2004
     # Ansible 9 (ansible-core 2.16) requires Python 2.7 or >= 3.6 on targets
-    ansible9: MITOGEN_TEST_DISTRO_SPECS=centos7 centos8 debian9 debian10 debian11 ubuntu1804 ubuntu2004
+    ans9: MITOGEN_TEST_DISTRO_SPECS=centos7 centos8 debian9 debian10 debian11 ubuntu1804 ubuntu2004
     # Ansible 10 (ansible-core 2.17) requires Python >= 3.7 on targets
-    ansible10: MITOGEN_TEST_DISTRO_SPECS=debian10-py3 debian11-py3 ubuntu2004-py3
+    ans10: MITOGEN_TEST_DISTRO_SPECS=debian10-py3 debian11-py3 ubuntu2004-py3
     # Ansible 11 (ansible-core 2.18) requires Python >= 3.8 on targets
-    ansible11: MITOGEN_TEST_DISTRO_SPECS=debian11-py3 ubuntu2004-py3
-    ansible12: MITOGEN_TEST_DISTRO_SPECS=debian11-py3 ubuntu2004-py3
+    ans11: MITOGEN_TEST_DISTRO_SPECS=debian11-py3 ubuntu2004-py3
+    ans12: MITOGEN_TEST_DISTRO_SPECS=debian11-py3 ubuntu2004-py3
     distros_centos: MITOGEN_TEST_DISTRO_SPECS=centos6 centos7 centos8
     distros_centos5: MITOGEN_TEST_DISTRO_SPECS=centos5
     distros_centos6: MITOGEN_TEST_DISTRO_SPECS=centos6
@@ -138,14 +136,14 @@ setenv =
     distros_ubuntu1604: MITOGEN_TEST_DISTRO_SPECS=ubuntu1604
     distros_ubuntu1804: MITOGEN_TEST_DISTRO_SPECS=ubuntu1804
     distros_ubuntu2004: MITOGEN_TEST_DISTRO_SPECS=ubuntu2004
-    mode_ansible: MODE=ansible
-    mode_ansible: ANSIBLE_SKIP_TAGS=resource_intensive
-    mode_ansible: ANSIBLE_CALLBACK_WHITELIST=profile_tasks
-    mode_ansible: ANSIBLE_CALLBACKS_ENABLED=profile_tasks
+    m_ans: MODE=ansible
+    m_ans: ANSIBLE_SKIP_TAGS=resource_intensive
+    m_ans: ANSIBLE_CALLBACK_WHITELIST=profile_tasks
+    m_ans: ANSIBLE_CALLBACKS_ENABLED=profile_tasks
     mode_debops_common: MODE=debops_common
-    mode_localhost: ANSIBLE_SKIP_TAGS=issue_776,resource_intensive
-    mode_mitogen: MODE=mitogen
-    strategy_linear: ANSIBLE_STRATEGY=linear
+    m_lcl: ANSIBLE_SKIP_TAGS=issue_776,resource_intensive
+    m_mtg: MODE=mitogen
+    s_lin: ANSIBLE_STRATEGY=linear
 allowlist_externals =
     # Added: Tox 3.18: Tox 4.0+
     *_install.py


### PR DESCRIPTION
This is to prevent job names being truncated in the Github Actions web UI. So
it is obvious at a glance which jobs have failed. Previously one had to click
into the details to know which job was which, leading to confusion and wasted
time.

This also

- removes braced ranges in `testenv.setenv`. They appear not to be supported by tox (see https://github.com/tox-dev/tox/issues/3571)
- fixes the env var `DEFAULT_STDOUT_CALLBACK` -> `ANSIBLE_STDOUT_CALLBACK`

as a result of these test output format was previously not as intended for
some Ansible versions.

fixes #1318