### PR TITLE
sudo: add mitogen_sudo_password_prompt for custom passprompt

### DIFF
--- a/ansible_mitogen/connection.py
+++ b/ansible_mitogen/connection.py
@@ -336,18 +336,24 @@ def _connect_sudo(spec):
     """
     Return ContextService arguments for sudo as a become method.
     """
+    kwargs = {
+        'username': spec.become_user(),
+        'password': spec.become_pass(),
+        'python_path': spec.python_path(),
+        'sudo_path': spec.become_exe(),
+        'connect_timeout': spec.timeout(),
+        'sudo_args': spec.sudo_args(),
+        'remote_name': get_remote_name(spec),
+    }
+
+    password_prompt = spec.mitogen_sudo_password_prompt()
+    if password_prompt is not None:
+        kwargs['password_prompt'] = password_prompt
+
     return {
         'method': 'sudo',
         'enable_lru': True,
-        'kwargs': {
-            'username': spec.become_user(),
-            'password': spec.become_pass(),
-            'python_path': spec.python_path(),
-            'sudo_path': spec.become_exe(),
-            'connect_timeout': spec.timeout(),
-            'sudo_args': spec.sudo_args(),
-            'remote_name': get_remote_name(spec),
-        }
+        'kwargs': kwargs,
     }
 
 
@@ -390,17 +396,23 @@ def _connect_mitogen_sudo(spec):
     """
     Return ContextService arguments for sudo as a first class connection.
     """
+    kwargs = {
+        'username': spec.remote_user(),
+        'password': spec.password(),
+        'python_path': spec.python_path(),
+        'sudo_path': spec.become_exe(),
+        'connect_timeout': spec.timeout(),
+        'sudo_args': spec.sudo_args(),
+        'remote_name': get_remote_name(spec),
+    }
+
+    password_prompt = spec.mitogen_sudo_password_prompt()
+    if password_prompt is not None:
+        kwargs['password_prompt'] = password_prompt
+
     return {
         'method': 'sudo',
-        'kwargs': {
-            'username': spec.remote_user(),
-            'password': spec.password(),
-            'python_path': spec.python_path(),
-            'sudo_path': spec.become_exe(),
-            'connect_timeout': spec.timeout(),
-            'sudo_args': spec.sudo_args(),
-            'remote_name': get_remote_name(spec),
-        }
+        'kwargs': kwargs,
     }
 
 

--- a/ansible_mitogen/transport_config.py
+++ b/ansible_mitogen/transport_config.py
@@ -410,6 +410,13 @@ class Spec(with_metaclass(abc.ABCMeta, object)):
         """
 
     @abc.abstractmethod
+    def mitogen_sudo_password_prompt(self):
+        """
+        Optional regex pattern to match the sudo password prompt.
+        Overrides the built-in PASSWORD_PROMPT_RE in mitogen.sudo.
+        """
+
+    @abc.abstractmethod
     def extra_args(self):
         """
         Connection-specific arguments.
@@ -619,6 +626,9 @@ class PlayContextSpec(Spec):
 
     def mitogen_ssh_compression(self):
         return self._connection.get_task_var('mitogen_ssh_compression')
+
+    def mitogen_sudo_password_prompt(self):
+        return self._connection.get_task_var('mitogen_sudo_password_prompt')
 
     def extra_args(self):
         return self._connection.get_extra_args()
@@ -870,6 +880,9 @@ class MitogenViaSpec(Spec):
 
     def mitogen_ssh_compression(self):
         return self._host_vars.get('mitogen_ssh_compression')
+
+    def mitogen_sudo_password_prompt(self):
+        return self._host_vars.get('mitogen_sudo_password_prompt')
 
     def extra_args(self):
         return []  # TODO

--- a/ansible_mitogen/transport_config.py
+++ b/ansible_mitogen/transport_config.py
@@ -415,6 +415,13 @@ class Spec(with_metaclass(abc.ABCMeta, object)):
         """
 
     @abc.abstractmethod
+    def mitogen_sudo_password_prompt(self):
+        """
+        Optional regex pattern to match the sudo password prompt.
+        Overrides the built-in PASSWORD_PROMPT_RE in mitogen.sudo.
+        """
+
+    @abc.abstractmethod
     def extra_args(self):
         """
         Connection-specific arguments.
@@ -624,6 +631,9 @@ class PlayContextSpec(Spec):
 
     def mitogen_ssh_compression(self):
         return self._connection.get_task_var('mitogen_ssh_compression')
+
+    def mitogen_sudo_password_prompt(self):
+        return self._connection.get_task_var('mitogen_sudo_password_prompt')
 
     def extra_args(self):
         return self._connection.get_extra_args()
@@ -875,6 +885,9 @@ class MitogenViaSpec(Spec):
 
     def mitogen_ssh_compression(self):
         return self._host_vars.get('mitogen_ssh_compression')
+
+    def mitogen_sudo_password_prompt(self):
+        return self._host_vars.get('mitogen_sudo_password_prompt')
 
     def extra_args(self):
         return []  # TODO

--- a/docs/ansible_detailed.rst
+++ b/docs/ansible_detailed.rst
@@ -995,6 +995,11 @@ When used as a become method:
   Mitogen produces remote processes named like
   `"mitogen:user@controller.name:1234"`, however this may be a privacy issue in
   some circumstances.
+* ``mitogen_sudo_password_prompt``: optional regular expression pattern to
+  match a custom sudo password prompt. Mitogen's built-in pattern matches
+  "password" in dozens of locales, but custom sudoers ``passprompt`` settings
+  that omit that word will cause the connection to hang. Set this to a pattern
+  matching your prompt, e.g. ``'\[sudo\] \w+@[\w.]+:'``.
 * ansible.cfg: ``timeout``
 
 When used as the ``mitogen_sudo`` connection method:
@@ -1003,6 +1008,7 @@ When used as the ``mitogen_sudo`` connection method:
 * ``ansible_user``: username to sudo as.
 * ``ansible_password``: password to sudo as.
 * ``sudo_flags``, ``become_flags``
+* ``mitogen_sudo_password_prompt``
 * ``ansible_python_interpreter``
 
 

--- a/docs/ansible_detailed.rst
+++ b/docs/ansible_detailed.rst
@@ -997,6 +997,11 @@ When used as a become method:
   Mitogen produces remote processes named like
   `"mitogen:user@controller.name:1234"`, however this may be a privacy issue in
   some circumstances.
+* ``mitogen_sudo_password_prompt``: optional regular expression pattern to
+  match a custom sudo password prompt. Mitogen's built-in pattern matches
+  "password" in dozens of locales, but custom sudoers ``passprompt`` settings
+  that omit that word will cause the connection to hang. Set this to a pattern
+  matching your prompt, e.g. ``'\[sudo\] \w+@[\w.]+:'``.
 * ansible.cfg: ``timeout``
 
 When used as the ``mitogen_sudo`` connection method:
@@ -1005,6 +1010,7 @@ When used as the ``mitogen_sudo`` connection method:
 * ``ansible_user``: username to sudo as.
 * ``ansible_password``: password to sudo as.
 * ``sudo_flags``, ``become_flags``
+* ``mitogen_sudo_password_prompt``
 * ``ansible_python_interpreter``
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,9 @@ To avail of fixes in an unreleased version, please download a ZIP file
 In progress (unreleased)
 ------------------------
 
+* :gh:issue:`1503` :mod:`ansible_mitogen`: Add ``mitogen_sudo_password_prompt``
+  variable to allow matching custom sudo password prompts that omit the word
+  "password"
 
 v0.3.47 (2026-04-19)
 --------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,9 @@ In progress
   source modifier feature
 * :gh:issue:`1540` tests: Test :class:`mitogen.master.ModuleFinder` source
   override
+* :gh:issue:`1503` :mod:`ansible_mitogen`: Add ``mitogen_sudo_password_prompt``
+  variable to allow matching custom sudo password prompts that omit the word
+  "password"
 
 
 v0.3.51 (2026-07-18)

--- a/mitogen/sudo.py
+++ b/mitogen/sudo.py
@@ -194,16 +194,17 @@ class Options(mitogen.parent.Options):
     sudo_path = 'sudo'
     username = 'root'
     password = None
+    password_prompt = None
     preserve_env = False
     set_home = False
     login = False
-
     selinux_role = None
     selinux_type = None
 
     def __init__(self, username=None, sudo_path=None, password=None,
-                 preserve_env=None, set_home=None, sudo_args=None,
-                 login=None, selinux_role=None, selinux_type=None, **kwargs):
+                 password_prompt=None, preserve_env=None, set_home=None,
+                 sudo_args=None, login=None, selinux_role=None,
+                 selinux_type=None, **kwargs):
         super(Options, self).__init__(**kwargs)
         opts = parse_sudo_flags(sudo_args or [])
 
@@ -211,6 +212,8 @@ class Options(mitogen.parent.Options):
         self.sudo_path = option(self.sudo_path, sudo_path)
         if password:
             self.password = mitogen.core.to_text(password)
+        if password_prompt:
+            self.password_prompt = password_prompt
         self.preserve_env = option(self.preserve_env,
             preserve_env, opts.preserve_env)
         self.set_home = option(self.set_home, set_home, opts.set_home)
@@ -250,6 +253,24 @@ class SetupProtocol(mitogen.parent.RegexProtocol):
 
 class Connection(mitogen.parent.Connection):
     diag_protocol_class = SetupProtocol
+
+    def stderr_stream_factory(self):
+        """
+        If password_prompt is configured, build a stream using a subclass of
+        SetupProtocol with the custom pattern prepended to PARTIAL_PATTERNS.
+        """
+        prompt = self.options.password_prompt
+        if not prompt:
+            return self.diag_protocol_class.build_stream()
+
+        custom_re = re.compile(prompt.encode('utf-8'), re.I)
+
+        class CustomSetupProtocol(SetupProtocol):
+            PARTIAL_PATTERNS = [
+                (custom_re, SetupProtocol._on_password_prompt),
+            ] + SetupProtocol.PARTIAL_PATTERNS
+
+        return CustomSetupProtocol.build_stream()
     options_class = Options
     create_child = staticmethod(mitogen.parent.hybrid_tty_create_child)
     create_child_args = {

--- a/mitogen/sudo.py
+++ b/mitogen/sudo.py
@@ -133,16 +133,17 @@ class Options(mitogen.parent.Options):
     sudo_path = 'sudo'
     username = 'root'
     password = None
+    password_prompt = None
     preserve_env = False
     set_home = False
     login = False
-
     selinux_role = None
     selinux_type = None
 
     def __init__(self, username=None, sudo_path=None, password=None,
-                 preserve_env=None, set_home=None, sudo_args=None,
-                 login=None, selinux_role=None, selinux_type=None, **kwargs):
+                 password_prompt=None, preserve_env=None, set_home=None,
+                 sudo_args=None, login=None, selinux_role=None,
+                 selinux_type=None, **kwargs):
         super(Options, self).__init__(**kwargs)
         opts = parse_sudo_flags(sudo_args or [])
 
@@ -150,6 +151,8 @@ class Options(mitogen.parent.Options):
         self.sudo_path = option(self.sudo_path, sudo_path)
         if password:
             self.password = mitogen.core.to_text(password)
+        if password_prompt:
+            self.password_prompt = password_prompt
         self.preserve_env = option(self.preserve_env,
             preserve_env, opts.preserve_env)
         self.set_home = option(self.set_home, set_home, opts.set_home)
@@ -195,6 +198,24 @@ class Connection(mitogen.parent.Connection):
         'escalates_privilege': True,
     }
     child_is_immediate_subprocess = False
+
+    def stderr_stream_factory(self):
+        """
+        If password_prompt is configured, build a stream using a subclass of
+        SetupProtocol with the custom pattern prepended to PARTIAL_PATTERNS.
+        """
+        prompt = self.options.password_prompt
+        if not prompt:
+            return self.diag_protocol_class.build_stream()
+
+        custom_re = re.compile(prompt.encode('utf-8'), re.I)
+
+        class CustomSetupProtocol(SetupProtocol):
+            PARTIAL_PATTERNS = [
+                (custom_re, SetupProtocol._on_password_prompt),
+            ] + SetupProtocol.PARTIAL_PATTERNS
+
+        return CustomSetupProtocol.build_stream()
 
     def _get_name(self):
         return u'sudo.' + mitogen.core.to_text(self.options.username)

--- a/tests/sudo_test.py
+++ b/tests/sudo_test.py
@@ -1,4 +1,7 @@
 import os
+import re
+
+import mitogen.sudo
 
 import testlib
 
@@ -56,6 +59,43 @@ class ConstructorTest(testlib.RouterMixin, testlib.TestCase):
             self.assertEqual('1', context.call(os.getenv, 'PREHISTORIC_SUDO'))
         finally:
             del os.environ['PREHISTORIC_SUDO']
+
+
+class PasswordPromptPatternTest(testlib.TestCase):
+    def _make_options(self, **kwargs):
+        return mitogen.sudo.Options(
+            max_message_size=mitogen.core.CHUNK_SIZE,
+            **kwargs
+        )
+
+    def test_default_has_no_custom_prompt(self):
+        options = self._make_options()
+        self.assertIsNone(options.password_prompt)
+
+    def test_custom_prompt_stored(self):
+        options = self._make_options(
+            password_prompt=r'\[sudo\] \w+@[\w.]+:',
+        )
+        self.assertEqual(options.password_prompt, r'\[sudo\] \w+@[\w.]+:')
+
+    def test_custom_protocol_prepends_pattern(self):
+        options = self._make_options(
+            password_prompt=r'\[sudo\] \w+@[\w.]+:',
+        )
+        conn = mitogen.sudo.Connection(options, router=None)
+        stream = conn.stderr_stream_factory()
+        patterns = stream.protocol.PARTIAL_PATTERNS
+        # custom pattern first, built-in second
+        self.assertEqual(len(patterns), 2)
+        self.assertEqual(patterns[0][0].pattern, b'\\[sudo\\] \\w+@[\\w.]+:')
+        self.assertIs(patterns[1][0], mitogen.sudo.PASSWORD_PROMPT_RE)
+
+    def test_no_custom_uses_default_protocol(self):
+        options = self._make_options()
+        conn = mitogen.sudo.Connection(options, router=None)
+        stream = conn.stderr_stream_factory()
+        self.assertIsInstance(stream.protocol, mitogen.sudo.SetupProtocol)
+        self.assertEqual(len(stream.protocol.PARTIAL_PATTERNS), 1)
 
 
 # TODO: https://github.com/dw/mitogen/issues/694

--- a/tests/sudo_test.py
+++ b/tests/sudo_test.py
@@ -108,6 +108,43 @@ class ConstructorTest(testlib.RouterMixin, testlib.TestCase):
             del os.environ['PREHISTORIC_SUDO']
 
 
+class PasswordPromptPatternTest(testlib.TestCase):
+    def _make_options(self, **kwargs):
+        return mitogen.sudo.Options(
+            max_message_size=mitogen.core.CHUNK_SIZE,
+            **kwargs
+        )
+
+    def test_default_has_no_custom_prompt(self):
+        options = self._make_options()
+        self.assertIsNone(options.password_prompt)
+
+    def test_custom_prompt_stored(self):
+        options = self._make_options(
+            password_prompt=r'\[sudo\] \w+@[\w.]+:',
+        )
+        self.assertEqual(options.password_prompt, r'\[sudo\] \w+@[\w.]+:')
+
+    def test_custom_protocol_prepends_pattern(self):
+        options = self._make_options(
+            password_prompt=r'\[sudo\] \w+@[\w.]+:',
+        )
+        conn = mitogen.sudo.Connection(options, router=None)
+        stream = conn.stderr_stream_factory()
+        patterns = stream.protocol.PARTIAL_PATTERNS
+        # custom pattern first, built-in second
+        self.assertEqual(len(patterns), 2)
+        self.assertEqual(patterns[0][0].pattern, b'\\[sudo\\] \\w+@[\\w.]+:')
+        self.assertIs(patterns[1][0], mitogen.sudo.PASSWORD_PROMPT_RE)
+
+    def test_no_custom_uses_default_protocol(self):
+        options = self._make_options()
+        conn = mitogen.sudo.Connection(options, router=None)
+        stream = conn.stderr_stream_factory()
+        self.assertIsInstance(stream.protocol, mitogen.sudo.SetupProtocol)
+        self.assertEqual(len(stream.protocol.PARTIAL_PATTERNS), 1)
+
+
 class SudoMixin(testlib.DockerMixin):
     def test_password_required(self):
         ssh = self.docker_ssh(


### PR DESCRIPTION
@jettero:
I didn't have much to do with this. Just asked claude to fix the problem I was having with mitogen in my ansible setup. The problem turned out to be my custom sudo prompts, which I'm not willing to change, so if I wanna use mitogen, I have to fork... But feel free to reject this if you don't like it. I don't have much skin in the game.

Claude:

Mitogen's PASSWORD_PROMPT_RE matches "password" in dozens of locales, covering any default sudo configuration. But if sudoers defines a custom passprompt (e.g. `[sudo] %u@%h:`) that omits the word "password", mitogen never recognizes the prompt, never sends the password, and the sudo bootstrap hangs until connect_timeout.

Ansible's own sudo become plugin sidesteps this by always forcing -p, but mitogen matches the prompt on the wire instead. This commit adds a configurable regex pattern via the ansible variable `mitogen_sudo_password_prompt`. When set, the pattern is compiled and prepended to SetupProtocol.PARTIAL_PATTERNS, with the built-in patterns as fallback.

Configuration (group_vars, host_vars, or play vars):

```yaml
    mitogen_sudo_password_prompt: '\[sudo\] \w+@[\w.]+:'
```

Also adds pyproject.toml so `pip install -e .` works with modern pip.


Thanks for creating a PR! Here's a quick checklist to pay attention to:

* Please add an entry to docs/changelog.rst as appropriate.

* Has some new parameter been added or semantics modified somehow? Please
  ensure relevant documentation is updated in docs/ansible.rst and
  docs/api.rst.

* If it's for new functionality, is there at least a basic test in either
  tests/ or tests/ansible/ covering it?

* If it's for a new connection method, please try to stub out the
  implementation as in tests/data/stubs/, so that construction can be tested
  without having a working configuration.

