### PR TITLE
mitogen: Increase maximum Context name length to 500 characters

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,6 +29,8 @@ In progress
 * :gh:issue:`1540` :mod:`ansible_mitogen`: Refactor "fixups" as source modifiers
 * :gh:issue:`1540` :mod:`mitogen`: Add :class:`mitogen.master.ModuleFinder`
   source modifier feature
+* :gh:issue:`1547` :mod:`mitogen`: Improve validation of ``Context`` attributes
+  attributes during creation and unpickling
 * :gh:issue:`1540` tests: Test :class:`mitogen.master.ModuleFinder` source
   override
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,8 @@ In progress
   source modifier feature
 * :gh:issue:`1547` :mod:`mitogen`: Improve validation of ``Context`` attributes
   attributes during creation and unpickling
+* :gh:issue:`689` :mod:`mitogen`: Bump :attr:`mitogen.core.Context.NAME_MAX_LEN`
+  to 500
 * :gh:issue:`1540` tests: Test :class:`mitogen.master.ModuleFinder` source
   override
 

--- a/mitogen/core.py
+++ b/mitogen/core.py
@@ -2565,7 +2565,7 @@ class Context(object):
     """
     ID_MIN = 0
     ID_MAX = 2**32 - 1
-    NAME_MAX_LEN = 99
+    NAME_MAX_LEN = 500
 
     def __init__(self, router, context_id, name=None):
         _require_bounds(context_id, Context.ID_MIN, Context.ID_MAX)

--- a/mitogen/core.py
+++ b/mitogen/core.py
@@ -436,6 +436,8 @@ class CallError(Error):
     <mitogen.parent.Context.call>` fails. A copy of the traceback from the
     external context is appended to the exception message.
     """
+    MSG_MAX_LEN = 9999
+
     def __init__(self, fmt=None, *args):
         if not isinstance(fmt, BaseException):
             Error.__init__(self, fmt, *args)
@@ -454,8 +456,8 @@ class CallError(Error):
 
 
 def _unpickle_call_error(s):
-    if not (type(s) is UnicodeType and len(s) < 10000):
-        raise TypeError('cannot unpickle CallError: bad input')
+    _require_types(s, (UnicodeType,))
+    _require_length(s, 0, CallError.MSG_MAX_LEN)
     return CallError(s)
 
 
@@ -479,6 +481,32 @@ class TimeoutError(Error):
     Raised when a timeout occurs on a stream.
     """
     pass
+
+
+def _require_bounds(v, min, max):
+    if not (min <= v <= max):
+        raise ValueError("Required bounds %d..%d, got %d" % (min, max, v))
+
+
+def _require_length(v, min, max):
+    if not min <= len(v) <= max:
+        raise ValueError("Required length %d..%d, got %d" % (min, max, len(v)))
+
+
+def _require_types(v, types):
+    if type(v) not in types:
+        raise TypeError("Required one of %r, got %s" % (types, type(v),))
+
+
+def _ensure_text(s, encoding='utf-8', errors='strict'):
+    """
+    Coerce a text or bytes string to UnicodeType, otherwise raise TypeError.
+
+    Unlike :func:`mitogen.core.to_text` don't stringify arbitrary objects.
+    """
+    if isinstance(s, UnicodeType): return UnicodeType(s)
+    if isinstance(s, BytesType): return s.decode(encoding, errors)
+    raise TypeError("Expected one of %r, got %s" % (AnyTextType, type(s)))
 
 
 def to_text(o):
@@ -1087,10 +1115,12 @@ class Sender(object):
 
 
 def _unpickle_sender(router, context_id, dst_handle):
-    if not (isinstance(router, Router) and
-            isinstance(context_id, integer_types) and context_id >= 0 and
-            isinstance(dst_handle, integer_types) and dst_handle > 0):
-        raise TypeError('cannot unpickle Sender: bad input or missing router')
+    _require_types(context_id, integer_types)
+    _require_bounds(context_id, Context.ID_MIN, Context.ID_MAX)
+    _require_types(dst_handle, integer_types)
+    _require_bounds(dst_handle, 1, 2**32-1)
+    if not isinstance(router, Router):
+        raise TypeError('Cannot unpickle Sender: missing router')
     return Sender(Context(router, context_id), dst_handle)
 
 
@@ -2533,14 +2563,18 @@ class Context(object):
     :param str name:
         Context name.
     """
-    name = None
-    remote_name = None
+    ID_MIN = 0
+    ID_MAX = 2**32 - 1
+    NAME_MAX_LEN = 99
 
     def __init__(self, router, context_id, name=None):
+        _require_bounds(context_id, Context.ID_MIN, Context.ID_MAX)
+        if name is not None:
+            name = _ensure_text(name)
+            _require_length(name, 0, Context.NAME_MAX_LEN)
         self.router = router
         self.context_id = context_id
-        if name:
-            self.name = to_text(name)
+        self.name = name
 
     def __reduce__(self):
         return _unpickle_context, (self.context_id, self.name)
@@ -2626,11 +2660,11 @@ class Context(object):
 
 
 def _unpickle_context(context_id, name, router=None):
-    if not (isinstance(context_id, integer_types) and context_id >= 0 and (
-        (name is None) or
-        (isinstance(name, UnicodeType) and len(name) < 100))
-    ):
-        raise TypeError('cannot unpickle Context: bad input')
+    _require_types(context_id, integer_types)
+    _require_bounds(context_id, Context.ID_MIN, Context.ID_MAX)
+    if name is not None:
+        _require_types(name, (UnicodeType,))
+        _require_length(name, 0, Context.NAME_MAX_LEN)
 
     if isinstance(router, Router):
         return router.context_by_id(context_id, name=name)

--- a/mitogen/parent.py
+++ b/mitogen/parent.py
@@ -1999,8 +1999,8 @@ class Context(mitogen.core.Context):
 
     via = None
 
-    def __init__(self, *args, **kwargs):
-        super(Context, self).__init__(*args, **kwargs)
+    def __init__(self, router, context_id, name=None):
+        super(Context, self).__init__(router, context_id, name)
         self.default_call_chain = self.call_chain_class(self)
 
     def __ne__(self, other):
@@ -2421,8 +2421,7 @@ class Router(mitogen.core.Router):
 
     def _connect(self, klass, **kwargs):
         context_id = self.allocate_id()
-        context = self.context_class(self, context_id)
-        context.name = kwargs.get('name')
+        context = self.context_class(self, context_id, kwargs.get('name'))
 
         kwargs['old_router'] = self
         kwargs['max_message_size'] = self.max_message_size

--- a/tests/context_test.py
+++ b/tests/context_test.py
@@ -1,13 +1,54 @@
 import pickle
 
 import mitogen.core
+import mitogen.parent
 
 import testlib
 
 
-class PickleTest(testlib.RouterMixin, testlib.TestCase):
-    klass = mitogen.core.Context
+class CoreMixin(object):
+    context_class = mitogen.core.Context
 
+
+class ParentMixin(object):
+    context_class = mitogen.parent.Context
+
+
+class TestsMixin(object):
+    def test_required_attrs(self):
+        router = object()
+        ctx = self.context_class(router, 42)
+        self.assertEqual(ctx.router, router)
+        self.assertEqual(ctx.context_id, 42)
+
+    def test_name_attr(self):
+        for arg, expected_val, expected_type in [
+            (mitogen.core.b(''),        u'',        mitogen.core.UnicodeType),
+            (mitogen.core.b('fred'),    u'fred',    mitogen.core.UnicodeType),
+            (u'',                       u'',        mitogen.core.UnicodeType),
+            (u'fred',                   u'fred',    mitogen.core.UnicodeType),
+        ]:
+            ctx = self.context_class(None, 42, arg)
+            self.assertEqual(ctx.name, expected_val)
+            self.assertTrue(isinstance(ctx.name, expected_type))
+
+    def test_name_type(self):
+        self.assertRaises(TypeError, self.context_class, None, 42, 43)
+
+    def test_name_length(self):
+        too_long = u'a' * (self.context_class.NAME_MAX_LEN + 1)
+        self.assertRaises(ValueError, self.context_class, None, 42, too_long)
+
+
+class CoreTest(TestsMixin, ParentMixin, testlib.TestCase):
+    pass
+
+
+class ParentTest(TestsMixin, ParentMixin, testlib.TestCase):
+    pass
+
+
+class PickleTest(testlib.RouterMixin, testlib.TestCase):
     # Ensure Context can be round-tripped by regular pickle in addition to
     # Mitogen's hacked pickle. Users may try to call pickle on a Context in
     # strange circumstances, and it's often used to glue pieces of an app

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -477,11 +477,13 @@ class UnpickleCompatTest(testlib.TestCase):
            ('\x80\x02cmitogen.core\n_unpickle_call_error\nq\x00X\t\x00\x00\x00big errorq\x01\x85q\x02R.'), throw=False)
 
     def test_py24_context(self):
-        self.check(mitogen.core.Context(1234, None),
+        self.check(
+            mitogen.core.Context(object(), 1234, None),
            ('\x80\x02cmitogen.core\n_unpickle_context\nq\x00M\xd2\x04N\x86q\x01Rq\x02.'))
 
     def test_py24_sender(self):
-        self.check(mitogen.core.Sender(mitogen.core.Context(55555, None), 4444),
+        self.check(
+            mitogen.core.Sender(mitogen.core.Context(object(), 55555, None), 4444),
            ('\x80\x02cmitogen.core\n_unpickle_sender\nq\x00M\x03\xd9M\\\x11\x86q\x01Rq\x02.'))
 
     def test_py27_bytes(self):
@@ -529,11 +531,13 @@ class UnpickleCompatTest(testlib.TestCase):
            ('\x80\x02cmitogen.core\n_unpickle_call_error\nq\x01X\t\x00\x00\x00big errorq\x02\x85Rq\x03.'), throw=False)
 
     def test_py27_context(self):
-        self.check(mitogen.core.Context(1234, None),
+        self.check(
+            mitogen.core.Context(object(), 1234, None),
            ('\x80\x02cmitogen.core\n_unpickle_context\nq\x01M\xd2\x04N\x86Rq\x02.'))
 
     def test_py27_sender(self):
-        self.check(mitogen.core.Sender(mitogen.core.Context(55555, None), 4444),
+        self.check(
+            mitogen.core.Sender(mitogen.core.Context(object(), 55555, None), 4444),
            ('\x80\x02cmitogen.core\n_unpickle_sender\nq\x01M\x03\xd9M\\\x11\x86Rq\x02.'))
 
     def test_py36_bytes(self):
@@ -581,11 +585,13 @@ class UnpickleCompatTest(testlib.TestCase):
            ('\x80\x02cmitogen.core\n_unpickle_call_error\nq\x00X\t\x00\x00\x00big errorq\x01\x85q\x02Rq\x03.'), throw=False)
 
     def test_py36_context(self):
-        self.check(mitogen.core.Context(1234, None),
+        self.check(
+            mitogen.core.Context(object(), 1234, None),
            ('\x80\x02cmitogen.core\n_unpickle_context\nq\x00M\xd2\x04N\x86q\x01Rq\x02.'))
 
     def test_py36_sender(self):
-        self.check(mitogen.core.Sender(mitogen.core.Context(55555, None), 4444),
+        self.check(
+            mitogen.core.Sender(mitogen.core.Context(object(), 55555, None), 4444),
            ('\x80\x02cmitogen.core\n_unpickle_sender\nq\x00M\x03\xd9M\\\x11\x86q\x01Rq\x02.'))
 
 

--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -455,6 +455,10 @@ class TestCase(unittest.TestCase):
         self._teardown_check_fds()
         super(TestCase, self).tearDown()
 
+    def assertIsType(self, a, expected_type):
+        if type(a) is not expected_type:
+            self.fail("Expected type %s, got %s" % (expected_type, type(a)))
+
     def assertRaises(self, exc, func, *args, **kwargs):
         """Like regular assertRaises, except return the exception that was
         raised. Can't use context manager because tests must run on Python2.4"""

--- a/tests/types_test.py
+++ b/tests/types_test.py
@@ -119,6 +119,28 @@ class AdornedUnicode(mitogen.core.UnicodeType):
     pass
 
 
+class EnsureTextTest(testlib.TestCase):
+    func = staticmethod(mitogen.core._ensure_text)
+
+    def test_bytes(self):
+        s = self.func(mitogen.core.b('bytes'))
+        self.assertIsType(s, mitogen.core.UnicodeType)
+        self.assertEqual(s, u'bytes')
+
+    def test_unicode(self):
+        s = self.func(u'text')
+        self.assertIsType(s, mitogen.core.UnicodeType)
+        self.assertEqual(s, u'text')
+
+    def test_adorned_unicode(self):
+        s = self.func(AdornedUnicode(u'text'))
+        self.assertIsType(s, mitogen.core.UnicodeType)
+        self.assertEqual(s, u'text')
+
+    def test_integer(self):
+        self.assertRaises(TypeError, self.func, 123)
+
+
 class ToTextTest(testlib.TestCase):
     func = staticmethod(mitogen.core.to_text)
 


### PR DESCRIPTION
Contexts now
- Explicitly check context_id will fit in a Message header
- Explicitly check name will be accepted when unpickled
- Reject non str-like name, instead of silently stringifying
- Always cast a str-like name to UnicodeType, if provided
- Use named constants for minimums and maximums
- Provide more useful errors if unpickling constraints are exceeded

I don't see any architectural or security driven reason for the old value. I've concluded it's relatively arbitrary and since people are hitting the existing limit in normal use it makes sense to increase it.

500 feels a reasonable balance - high enough people are unlikely to hit it in normal use, low enough that incorrect use will be detected sooner than later.

refs #1547, fixes #689